### PR TITLE
Speed up getting used ipaddreses by limiting to the actual subnet.

### DIFF
--- a/mreg/api/v1/views.py
+++ b/mreg/api/v1/views.py
@@ -649,6 +649,7 @@ class SubnetDetail(ETAGMixin, generics.GenericAPIView):
         from_ip = str(network.network_address)
         to_ip = str(network.broadcast_address)
         ips = Ipaddress.objects.filter(ipaddress__gt=from_ip)
+        # XXX:  __lt does not work correctly with sqlite :( postgres is OK.
         ips = ips.filter(ipaddress__lt=to_ip)
         used = {ipaddress.ip_address(i.ipaddress) for i in ips}
         return used


### PR DESCRIPTION
Also speed up get_used_ipaddresses_on_subnet() by ignoring unused-addreses,
which it doesn't need.

While here optimize get_first_unused() by finding the first unused IP itself,
and not depending on at potentially very slow get_unused_ipaddresses_on_subnet().

Also while here, fix a tiny bug in HostList.post() with assuming the request.data
is always a QueryDict, but it is just a normal dict when using the Django website
directly.

usit-gd/mreg#94