### PR TITLE
Upgrade requests to 2.20.0, due to CVE-2018-18074.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ openapi-codec==1.3.2
 psycopg2==2.7.5
 psycopg2-binary==2.7.5
 pytz==2018.5
-requests==2.19.1
+requests==2.20.0
 simplejson==3.16.0
 six==1.11.0
 uritemplate==3.0.0


### PR DESCRIPTION
Resolves usit-gd/mreg#122.