### PR TITLE
Fix get (un)used ipaddresses again

### DIFF
--- a/mreg/api/v1/tests.py
+++ b/mreg/api/v1/tests.py
@@ -916,6 +916,15 @@ class APISubnetsTestCase(TestCase):
         response = self.client.patch('/subnets/193.101.168.0/29', self.patch_data)
         self.assertEqual(response.status_code, 404)
 
+    def test_subnets_get_usedcount_200_ok(self):
+        """GET on /subnets/<ip/mask> with QUERY_STRING header 'used_count' should return 200 ok and data."""
+        ip_sample = Ipaddress(hostid=self.host_one, ipaddress='129.240.204.17')
+        clean_and_save(ip_sample)
+
+        response = self.client.get('/subnets/%s?used_count' % self.subnet_sample.range)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, 1)
+
     def test_subnets_get_usedlist_200_ok(self):
         """GET on /subnets/<ip/mask> with QUERY_STRING header 'used_list' should return 200 ok and data."""
         ip_sample = Ipaddress(hostid=self.host_one, ipaddress='129.240.204.17')
@@ -924,6 +933,33 @@ class APISubnetsTestCase(TestCase):
         response = self.client.get('/subnets/%s?used_list' % self.subnet_sample.range)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, ['129.240.204.17'])
+
+    def test_subnets_get_unusedcount_200_ok(self):
+        """GET on /subnets/<ip/mask> with QUERY_STRING header 'unused_count' should return 200 ok and data."""
+        ip_sample = Ipaddress(hostid=self.host_one, ipaddress='129.240.204.17')
+        clean_and_save(ip_sample)
+
+        response = self.client.get('/subnets/%s?unused_count' % self.subnet_sample.range)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, 250)
+
+    def test_subnets_get_unusedlist_200_ok(self):
+        """GET on /subnets/<ip/mask> with QUERY_STRING header 'unused_list' should return 200 ok and data."""
+        ip_sample = Ipaddress(hostid=self.host_one, ipaddress='129.240.204.17')
+        clean_and_save(ip_sample)
+
+        response = self.client.get('/subnets/%s?unused_list' % self.subnet_sample.range)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 250)
+
+    def test_subnets_get_first_unused_200_ok(self):
+        """GET on /subnets/<ip/mask> with QUERY_STRING header 'first_unused' should return 200 ok and data."""
+        ip_sample = Ipaddress(hostid=self.host_one, ipaddress='129.240.204.17')
+        clean_and_save(ip_sample)
+
+        response = self.client.get('/subnets/%s?first_unused' % self.subnet_sample.range)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, '129.240.204.4')
 
     def test_subnets_delete_204_no_content(self):
         """Deleting an existing entry with no adresses in use should return 204"""

--- a/mreg/api/v1/views.py
+++ b/mreg/api/v1/views.py
@@ -565,7 +565,7 @@ class SubnetDetail(ETAGMixin, generics.GenericAPIView):
             unused_ipaddresses = self.get_unused_ipaddresses_on_subnet(iprange, reserved)
             return Response(unused_ipaddresses, status=status.HTTP_200_OK)
         elif request.META.get('QUERY_STRING') == 'first_unused':
-            ip = self.get_first_unused(serializer.data, reserved)
+            ip = self.get_first_unused(iprange, reserved)
             if ip:
                 return Response(ip, status=status.HTTP_200_OK)
             else:
@@ -648,7 +648,7 @@ class SubnetDetail(ETAGMixin, generics.GenericAPIView):
         Takes a network range and reserved addresses, and returns which
         ip-addresses on the subnet are unused.
         """
-        network = ipaddress.ip_network(subnet['range'])
+        network = ipaddress.ip_network(subnet)
         subnet_ips = []
         if isinstance(network, ipaddress.IPv6Network):
             # Getting all availible IPs for a ipv6 prefix can easily cause


### PR DESCRIPTION
The tests actually found the bug in get_unused_ipaddresses. I manually stumbled upon the other one.
Really resolves #146.