### PR TITLE
Only allow the MAC address to be in lower case and with colon as delimiter.

### DIFF
--- a/mreg/validators.py
+++ b/mreg/validators.py
@@ -88,7 +88,7 @@ def validate_zonename(name):
 
 def validate_mac_address(address):
     """Validates that the mac address is on a valid form."""
-    adr_regex = "^([a-fA-F0-9]{2}[-:]?){5}[a-fA-F0-9]{2}$"
+    adr_regex = "^([a-f0-9]{2}:){5}[a-f0-9]{2}$"
     validator = RegexValidator(adr_regex)
     validator(address)
 


### PR DESCRIPTION
Resolves #178.