### PR TITLE
After removing lots of null=True in the models, do not use None for empty fields.

### DIFF
--- a/mreg/api/v1/zonefile.py
+++ b/mreg/api/v1/zonefile.py
@@ -26,7 +26,7 @@ class ForwardFile(object):
             data += ip.zf_string(self.zone.name)
         if host.hinfo is not None:
             data += host.hinfo.zf_string
-        if host.loc is not None:
+        if host.loc:
             data += host.loc_string(self.zone.name)
         for cname in host.cnames.all():
             data += cname.zf_string(self.zone.name)

--- a/mreg/utils.py
+++ b/mreg/utils.py
@@ -63,14 +63,12 @@ def encode_mail(mail):
 
 def nonify(value):
     """
-    Checks if value is -1 or empty string and return None. If not, return original value.
+    Checks if value is -1, return empty string. If not, return original value.
     :param value: Value to check.
     :return: None or original value.
     """
     if value == -1:
-        return None
-    elif value == "":
-        return None
+        return ""
     else:
         return value
 


### PR DESCRIPTION
This convenience wrapper causes problems with fields which no
longer have null=True, but instead rely on blank=True.

Caused by #174.