### PR TITLE
Add API to logout a token. Actually just delete it.

### DIFF
--- a/mreg/api/urls.py
+++ b/mreg/api/urls.py
@@ -3,6 +3,6 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path('logout/', views.Logout.as_view()),
+    path('token-logout/', views.TokenLogout.as_view()),
     path('token-auth/', views.ObtainExpiringAuthToken.as_view()),
 ]

--- a/mreg/api/urls.py
+++ b/mreg/api/urls.py
@@ -3,5 +3,6 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
+    path('logout/', views.Logout.as_view()),
     path('token-auth/', views.ObtainExpiringAuthToken.as_view()),
 ]

--- a/mreg/api/v1/tests.py
+++ b/mreg/api/v1/tests.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from django.conf import settings
 from django.contrib.auth.models import Group, User
 from django.test import TestCase
@@ -556,6 +558,33 @@ def get_token_client():
     client = APIClient()
     client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
     return client
+
+class APITokenAutheticationTestCase(APITestCase):
+    """Test various token authentication operations."""
+
+    def setUp(self):
+        self.client = get_token_client()
+
+    def test_logout(self):
+        ret = self.client.get("/zones/")
+        self.assertEqual(ret.status_code, 200)
+        ret = self.client.post("/api/logout/")
+        self.assertEqual(ret.status_code, 200)
+        ret = self.client.get("/zones/")
+        self.assertEqual(ret.status_code, 401)
+
+    def test_force_expire(self):
+        ret = self.client.get("/zones/")
+        self.assertEqual(ret.status_code, 200)
+        user = User.objects.get(username='nobody')
+        token = Token.objects.get(user=user)
+        EXPIRE_HOURS = getattr(settings, 'REST_FRAMEWORK_TOKEN_EXPIRE_HOURS', 8)
+        token.created = timezone.now() - timedelta(hours=EXPIRE_HOURS)
+        token.save()
+        ret = self.client.get("/zones/")
+        self.assertEqual(ret.status_code, 401)
+
+
 
 class APIAutoupdateZonesTestCase(APITestCase):
     """This class tests the autoupdate of zones' updated_at whenever

--- a/mreg/api/v1/tests.py
+++ b/mreg/api/v1/tests.py
@@ -568,7 +568,7 @@ class APITokenAutheticationTestCase(APITestCase):
     def test_logout(self):
         ret = self.client.get("/zones/")
         self.assertEqual(ret.status_code, 200)
-        ret = self.client.post("/api/logout/")
+        ret = self.client.post("/api/token-logout/")
         self.assertEqual(ret.status_code, 200)
         ret = self.client.get("/zones/")
         self.assertEqual(ret.status_code, 401)

--- a/mreg/api/views.py
+++ b/mreg/api/views.py
@@ -23,7 +23,7 @@ class ObtainExpiringAuthToken(ObtainAuthToken):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
-class Logout(APIView):
+class TokenLogout(APIView):
     def post(self, request):
         # simply delete the token to force a login
         request.user.auth_token.delete()

--- a/mreg/api/views.py
+++ b/mreg/api/views.py
@@ -1,10 +1,11 @@
 import datetime
 from pytz import utc
 from rest_framework import status
-from rest_framework.response import Response
 from rest_framework.authtoken.models import Token
 from rest_framework.authtoken.views import ObtainAuthToken
 from rest_framework.authtoken.serializers import AuthTokenSerializer
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
 
 class ObtainExpiringAuthToken(ObtainAuthToken):
@@ -20,3 +21,10 @@ class ObtainExpiringAuthToken(ObtainAuthToken):
 
             return Response({'token': token.key})
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+class Logout(APIView):
+    def post(self, request):
+        # simply delete the token to force a login
+        request.user.auth_token.delete()
+        return Response(status=status.HTTP_200_OK)


### PR DESCRIPTION
Resolves #265.