### PR TITLE
Update to DRF 3.9.2 to prepare for Django 2.2.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cached-property==1.5.1
-certifi==2018.11.29
+certifi==2019.3.9
 chardet==3.0.4
 coreapi==2.3.3
 coreschema==0.0.4
@@ -8,7 +8,7 @@ django-auth-ldap==1.7.0
 django-logging-json==1.15
 django-rest-swagger==2.2.0
 django-url-filter==0.3.12
-djangorestframework==3.9.1
+djangorestframework==3.9.2
 drf-extensions==0.4.0
 elasticsearch==6.3.1
 enum-compat==0.0.2
@@ -16,16 +16,16 @@ gunicorn==19.9.0
 idna==2.8
 itypes==1.1.0
 Jinja2==2.10
-MarkupSafe==1.1.0
+MarkupSafe==1.1.1
 openapi-codec==1.3.2
 psycopg2==2.7.7
 psycopg2-binary==2.7.7
 pyasn1==0.4.5
 pyasn1-modules==0.2.4
-python-ldap==3.1.0
+python-ldap==3.2.0
 pytz==2018.9
 requests==2.21.0
-sentry-sdk==0.7.3
+sentry-sdk==0.7.8
 simplejson==3.16.0
 six==1.12.0
 uritemplate==3.0.0


### PR DESCRIPTION
Also adds a small nice feature which is handy now when coding
authorization: https://github.com/encode/django-rest-framework/pull/6463

While here update the other requirements to latest.