### PR TITLE
Update urllib3 to 1.25 due to CVE-2019-11324

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,5 +30,5 @@ sentry-sdk==0.7.8
 simplejson==3.16.0
 six==1.12.0
 uritemplate==3.0.0
-urllib3==1.24.1
+urllib3==1.25
 coverage==4.5.3


### PR DESCRIPTION
See https://nvd.nist.gov/vuln/detail/CVE-2019-11324