### PR TITLE
Add default timestamp value to ModelChangelog

### DIFF
--- a/mreg/models.py
+++ b/mreg/models.py
@@ -605,7 +605,7 @@ class ModelChangeLog(models.Model):
     table_row = models.BigIntegerField()
     data = models.TextField()
     action = models.CharField(max_length=16)  # saved or deleted
-    timestamp = models.DateTimeField()
+    timestamp = models.DateTimeField(auto_now_add=True)
 
     class Meta:
         db_table = "model_change_log"

--- a/mreg/signals.py
+++ b/mreg/signals.py
@@ -157,8 +157,7 @@ def save_host_history_on_save(sender, instance, created, **kwargs):
     new_log_entry = ModelChangeLog(table_name='host',
                                    table_row=hostdata['id'],
                                    data=hostdata,
-                                   action='saved',
-                                   timestamp=timezone.now())
+                                   action='saved')
     new_log_entry.save()
 
 
@@ -180,8 +179,7 @@ def save_host_history_on_delete(sender, instance, **kwargs):
     new_log_entry = ModelChangeLog(table_name='host',
                                    table_row=hostdata['id'],
                                    data=hostdata,
-                                   action='deleted',
-                                   timestamp=timezone.now())
+                                   action='deleted')
     new_log_entry.save()
 
 


### PR DESCRIPTION
Stop providing 'now' when creating new ModelChangelog entries.
It is enough to specify it when 'now' is wrong.