### PR TITLE
Add support for /32 & /128 networks

### DIFF
--- a/mreg/models/network.py
+++ b/mreg/models/network.py
@@ -275,6 +275,7 @@ class NetGroupRegexPermission(BaseModel):
         )
         if require_ip:
             qs = qs.filter(
-                reduce(lambda x, y: x | y, [Q(range__net_contains=ip) for ip in ips])
+                # NOTE: using `contains_or_equals` to match /32 (v4) and /128 (v6) CIDR ranges
+                reduce(lambda x, y: x | y, [Q(range__net_contains_or_equals=ip) for ip in ips])
             )
         return qs


### PR DESCRIPTION
Adds support for /32 (IPv4) and /128 (IPv6) networks, which was initially part of #584, but was later removed. This PR adds that functionality back.