### PR TITLE
Fix host prefetching

### DIFF
--- a/mreg/api/v1/views.py
+++ b/mreg/api/v1/views.py
@@ -18,7 +18,7 @@ from mreg.models.base import NameServer, History
 from mreg.models.host import Host, Ipaddress, PtrOverride
 from mreg.models.network import Network, NetGroupRegexPermission
 from mreg.models.resource_records import Cname, Loc, Naptr, Srv, Sshfp, Txt, Hinfo, Mx
-from mreg.models.network_policy import Community, NetworkPolicy
+from mreg.models.network_policy import Community, HostCommunityMapping, NetworkPolicy
 from mreg.types import IPAllocationMethod
 
 from mreg.api.permissions import (
@@ -327,9 +327,11 @@ class HinfoDetail(HostPermissionsUpdateDestroy,
 
 def _host_prefetcher(qs):
     return qs.prefetch_related(
-        "bacnetid", "cnames", "hinfo", "loc", "mxs", "ptr_overrides", "txts"
+        "bacnetid", "cnames", "hinfo", "loc", "mxs", "ptr_overrides", "txts",
+        "srvs", "naptrs", "sshfp_set", "hostgroups", "hostpolicyroles", "contacts",
     ).prefetch_related(
-        Prefetch("ipaddresses", queryset=Ipaddress.objects.order_by("ipaddress"))
+        Prefetch("ipaddresses", queryset=Ipaddress.objects.order_by("ipaddress")),
+        Prefetch("hostcommunitymapping_set", queryset=HostCommunityMapping.objects.select_related("community")),
     )
 
 

--- a/mreg/models/host.py
+++ b/mreg/models/host.py
@@ -162,7 +162,7 @@ class Host(ForwardZoneMember):
         Returns:
             List of email addresses
         """
-        return list(self.contacts.values_list('email', flat=True))
+        return [c.email for c in self.contacts.all()]
 
     def _resolve_community_mapping(
         self,


### PR DESCRIPTION
This PR fixes extra queries for fields not part of the host prefetcher by adding the missing fields. Furthermore, host contacts are now fetched via `self.contacts.all()` instead of `self.contacts.values_list()`, which correctly uses prefetched contacts.


## Profiling

Profiled request: `GET /api/v1/hosts/?ordering=name&page_size=1000&name__regex=.` (1000 hosts)


### Prefetched (correctly)

`bacnetid`, `cnames`, `hinfo`, `loc`, `mxs`, `ptr_overrides`, `txts`,`ipaddresses`

### Not prefetched (missing)

| Serializer field | Source relation     | Extra queries |
|------------------|---------------------|---------------|
| `srvs`           | `srvs`              | 1 000         |
| `naptrs`         | `naptrs`            | 1 000         |
| `sshfps`         | `sshfp_set`         | 1 000         |
| `hostgroups`     | `hostgroups`        | 1 000         |
| `roles`          | `hostpolicyroles`   | 1 000         |
| `contacts`       | `contacts`          | 1 000         |
| `communities`    | `hostcommunitymapping_set` | 1 000  |

### Process

I ran [django-silk](https://github.com/jazzband/django-silk) with profiling active when fetching 1000 hosts. That resulted in [this output](https://gist.github.com/pederhan/388f406b6df2af82104754069ccbc1a7), as well as this result from django-silk:

<img width="382" height="206" alt="image" src="https://github.com/user-attachments/assets/cf8f3a39-9cf6-40e0-9f73-746977a38c2e" />

I then passed these results to Claude Code, which determined that the bottleneck was host prefetching. This PR is the result of its proposed changes to remedy the situation.

<img width="974" height="312" alt="image" src="https://github.com/user-attachments/assets/becb6d7e-1dd8-4ef1-8e86-6678f0481500" />

_After and before_