### PR TITLE
Fix OpenAPI schema generation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,14 +63,16 @@ jobs:
         run: |
           export MREG_DB_NAME=mreg MREG_DB_USER=mreg MREG_DB_PASSWORD=postgres
           uv run manage.py makemigrations --check
-      # - name: Export OpenAPI schema
-      #   run: uv run manage.py generateschema > openapi.yml
-      # - name: Upload OpenAPI schema
-      #   if: matrix.python-version == '3.10'
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: openapi.yml
-      #     path: openapi.yml
+      - name: Validate OpenAPI schema
+        run: |
+          export MREG_DB_NAME=mreg MREG_DB_USER=mreg MREG_DB_PASSWORD=postgres
+          uv run manage.py spectacular --validate --file openapi.yml
+      - name: Upload OpenAPI schema
+        if: matrix.python-version == '3.10'
+        uses: actions/upload-artifact@v4
+        with:
+          name: openapi.yml
+          path: openapi.yml
       - name: Upload coverage
         uses: actions/upload-artifact@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache/
+openapi.yml
 
 # Translations
 *.mo

--- a/hostpolicy/api/v1/views.py
+++ b/hostpolicy/api/v1/views.py
@@ -1,12 +1,12 @@
 from django.db.models import Prefetch
 from rest_framework import status
-from rest_framework.response import Response
 
 from django_filters import rest_framework as filters
 from rest_framework import filters as rest_filters
 
 from hostpolicy.api.permissions import IsSuperOrHostPolicyAdminOrReadOnly
 from hostpolicy.models import HostPolicyAtom, HostPolicyRole
+from mreg.api.responses import error_response
 from mreg.api.v1.history import HistoryLog
 from mreg.api.v1.serializers import HostNameSerializer
 from mreg.api.v1.views import (
@@ -111,8 +111,7 @@ class HostPolicyAtomList(HostPolicyAtomLogMixin, LowerCaseLookupMixin, MregListC
 
     def post(self, request, *args, **kwargs):
         if self.get_object_from_request(request):
-            content = {"error": "name already in use"}
-            return Response(content, status=status.HTTP_409_CONFLICT)
+            return error_response("name already in use", status.HTTP_409_CONFLICT)
 
         return super().post(request, *args, **kwargs)
 
@@ -142,8 +141,7 @@ class HostPolicyRoleList(HostPolicyRoleLogMixin, LowerCaseLookupMixin, MregListC
 
     def post(self, request, *args, **kwargs):
         if self.get_object_from_request(request):
-            content = {"error": "name already in use"}
-            return Response(content, status=status.HTTP_409_CONFLICT)
+            return error_response("name already in use", status.HTTP_409_CONFLICT)
         return super().post(request, *args, **kwargs)
 
 

--- a/hostpolicy/api/v1/views.py
+++ b/hostpolicy/api/v1/views.py
@@ -199,7 +199,8 @@ class HostPolicyRoleAtomsDetail(HostPolicyM2MDetail):
 
     serializer_class = serializers.HostPolicyAtomSerializer
     m2m_field = 'atoms'
-    lookup_field = 'atom'
+    lookup_field = 'name'
+    lookup_url_kwarg = 'atom'
 
 
 class HostPolicyRoleHostsList(HostPolicyM2MList):
@@ -230,4 +231,5 @@ class HostPolicyRoleHostsDetail(HostPolicyM2MDetail):
 
     serializer_class = HostNameSerializer
     m2m_field = 'hosts'
-    lookup_field = 'host'
+    lookup_field = 'name'
+    lookup_url_kwarg = 'host'

--- a/hostpolicy/api/v1/views.py
+++ b/hostpolicy/api/v1/views.py
@@ -111,7 +111,7 @@ class HostPolicyAtomList(HostPolicyAtomLogMixin, LowerCaseLookupMixin, MregListC
 
     def post(self, request, *args, **kwargs):
         if self.get_object_from_request(request):
-            content = {"ERROR": "name already in use"}
+            content = {"error": "name already in use"}
             return Response(content, status=status.HTTP_409_CONFLICT)
 
         return super().post(request, *args, **kwargs)
@@ -142,7 +142,7 @@ class HostPolicyRoleList(HostPolicyRoleLogMixin, LowerCaseLookupMixin, MregListC
 
     def post(self, request, *args, **kwargs):
         if self.get_object_from_request(request):
-            content = {"ERROR": "name already in use"}
+            content = {"error": "name already in use"}
             return Response(content, status=status.HTTP_409_CONFLICT)
         return super().post(request, *args, **kwargs)
 

--- a/mreg/api/permissions.py
+++ b/mreg/api/permissions.py
@@ -6,6 +6,7 @@ from rest_framework import exceptions
 from rest_framework.permissions import IsAuthenticated as DRFIsAuthenticated, SAFE_METHODS
 from rest_framework.request import Request
 
+from mreg.api.responses import error_body
 from mreg.api.v1.serializers import HostSerializer
 from mreg.models.host import HostGroup
 from mreg.models.network import NetGroupRegexPermission, Network
@@ -372,7 +373,7 @@ class IsGrantedReservedAddressPermission(IsAuthenticated):
         else:
             if ipaddr in (network.network.broadcast_address, network.network.network_address):
                 raise exceptions.PermissionDenied(
-                    {"error": "Setting a network or broadcast address on a host requires network admin privileges."}
+                    error_body("Setting a network or broadcast address on a host requires network admin privileges.")
                 )
         return True
 
@@ -388,4 +389,3 @@ class IsGrantedReservedAddressPermission(IsAuthenticated):
         # in a `BaseModel` instance instead of a serializer when checking
         # destroy permissions, so we cannot access any sort of validated data.
         return self.has_permission(request, view)
-

--- a/mreg/api/permissions.py
+++ b/mreg/api/permissions.py
@@ -372,7 +372,7 @@ class IsGrantedReservedAddressPermission(IsAuthenticated):
         else:
             if ipaddr in (network.network.broadcast_address, network.network.network_address):
                 raise exceptions.PermissionDenied(
-                    {"ERROR": "Setting a network or broadcast address on a host requires network admin privileges."}
+                    {"error": "Setting a network or broadcast address on a host requires network admin privileges."}
                 )
         return True
 

--- a/mreg/api/responses.py
+++ b/mreg/api/responses.py
@@ -1,0 +1,9 @@
+from rest_framework.response import Response
+
+
+def error_body(message: str) -> dict[str, str]:
+    return {"error": message}
+
+
+def error_response(message: str, status: int) -> Response:
+    return Response(error_body(message), status=status)

--- a/mreg/api/serializers.py
+++ b/mreg/api/serializers.py
@@ -1,0 +1,58 @@
+from rest_framework import serializers
+
+
+class TokenStateSerializer(serializers.Serializer):
+    is_valid = serializers.BooleanField()
+    created = serializers.DateTimeField()
+    expire = serializers.DateTimeField()
+    last_used = serializers.DateTimeField(allow_null=True)
+    lifespan = serializers.CharField()
+
+
+class DjangoUserStatusSerializer(serializers.Serializer):
+    superuser = serializers.BooleanField()
+    staff = serializers.BooleanField()
+    active = serializers.BooleanField()
+
+
+class MregUserStatusSerializer(serializers.Serializer):
+    superuser = serializers.BooleanField()
+    admin = serializers.BooleanField()
+    group_admin = serializers.BooleanField()
+    network_admin = serializers.BooleanField()
+    hostpolicy_admin = serializers.BooleanField()
+    dns_wildcard_admin = serializers.BooleanField()
+    underscore_admin = serializers.BooleanField()
+
+
+class UserPermissionSerializer(serializers.Serializer):
+    group = serializers.CharField()
+    range = serializers.CharField()
+    regex = serializers.CharField()
+    labels = serializers.ListField(child=serializers.CharField())
+
+
+class UserInfoSerializer(serializers.Serializer):
+    username = serializers.CharField()
+    last_login = serializers.DateTimeField(allow_null=True)
+    token = TokenStateSerializer(allow_null=True)
+    django_status = DjangoUserStatusSerializer()
+    mreg_status = MregUserStatusSerializer()
+    groups = serializers.ListField(child=serializers.CharField())
+    permissions = UserPermissionSerializer(many=True)
+
+
+class MregVersionSerializer(serializers.Serializer):
+    version = serializers.CharField()
+
+
+class MetaVersionsSerializer(serializers.Serializer):
+    python = serializers.CharField()
+    django = serializers.CharField()
+    djangorestframework = serializers.CharField()
+    libpq = serializers.CharField()
+
+
+class HealthHeartbeatSerializer(serializers.Serializer):
+    start_time = serializers.IntegerField()
+    uptime = serializers.IntegerField()

--- a/mreg/api/serializers.py
+++ b/mreg/api/serializers.py
@@ -1,6 +1,21 @@
 from rest_framework import serializers
 
 
+REPORTED_LIBRARY_VERSION_FIELDS = (
+    "djangorestframework",
+    "django-auth-ldap",
+    "django-filter",
+    "django-logging-json",
+    "django-netfields",
+    "drf-standardized-errors",
+    "gunicorn",
+    "sentry-sdk",
+    "structlog",
+    "rich",
+    "psycopg",
+)
+
+
 class TokenStateSerializer(serializers.Serializer):
     is_valid = serializers.BooleanField()
     created = serializers.DateTimeField()
@@ -49,8 +64,13 @@ class MregVersionSerializer(serializers.Serializer):
 class MetaVersionsSerializer(serializers.Serializer):
     python = serializers.CharField()
     django = serializers.CharField()
-    djangorestframework = serializers.CharField()
     libpq = serializers.CharField()
+
+    def get_fields(self):
+        fields = super().get_fields()
+        for library in REPORTED_LIBRARY_VERSION_FIELDS:
+            fields[library] = serializers.CharField()
+        return fields
 
 
 class HealthHeartbeatSerializer(serializers.Serializer):

--- a/mreg/api/tests/test_openapi.py
+++ b/mreg/api/tests/test_openapi.py
@@ -1,0 +1,28 @@
+from django.test import SimpleTestCase
+
+from drf_spectacular.generators import SchemaGenerator
+
+
+class OpenAPISchemaTest(SimpleTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.schema = SchemaGenerator().get_schema(request=None, public=True)
+
+    def test_public_endpoints_do_not_require_authentication(self):
+        paths = self.schema["paths"]
+
+        self.assertEqual(paths["/api/token-auth/"]["post"].get("security", []), [])
+        self.assertEqual(paths["/api/meta/metrics"]["get"].get("security", []), [])
+
+    def test_user_info_documents_username_query_parameter(self):
+        operation = self.schema["paths"]["/api/meta/user"]["get"]
+        username = next(
+            parameter
+            for parameter in operation.get("parameters", [])
+            if parameter["name"] == "username"
+        )
+
+        self.assertEqual(username["in"], "query")
+        self.assertFalse(username.get("required", False))
+        self.assertEqual(username["schema"], {"type": "string"})

--- a/mreg/api/v1/serializers.py
+++ b/mreg/api/v1/serializers.py
@@ -30,16 +30,21 @@ class ValidationMixin:
         return data
 
 
+class ErrorResponseSerializer(serializers.Serializer):
+    ERROR = serializers.CharField(required=False)
+    error = serializers.CharField(required=False)
+
+
 class CommunitySerializer(serializers.ModelSerializer):
 
     # Members are all the hosts that have this community assigned.
     hosts = serializers.SerializerMethodField(read_only=True)
     global_name = serializers.SerializerMethodField(read_only=True)
 
-    def get_hosts(self, obj):
+    def get_hosts(self, obj) -> list[str]:
         return list(obj.hosts.values_list("name", flat=True))
 
-    def get_global_name(self, obj):
+    def get_global_name(self, obj) -> str | None:
         # Only map if the setting is enabled.
         if not getattr(settings, "MREG_MAP_GLOBAL_COMMUNITY_NAMES", False):
             return None
@@ -250,6 +255,8 @@ class HistorySerializer(serializers.ModelSerializer):
 
 
 class BACnetIDSerializer(serializers.ModelSerializer):
+    hostname = serializers.CharField(read_only=True)
+
     class Meta:
         model = BACnetID
         fields = ('id', 'host', 'hostname',)
@@ -267,6 +274,32 @@ class HostContactSerializer(serializers.ModelSerializer):
         model = HostContact
         fields = ('id', 'email', 'created_at', 'updated_at')
         read_only_fields = ('id', 'created_at', 'updated_at')
+
+
+class HostContactMutationSerializer(serializers.Serializer):
+    emails = serializers.ListField(child=serializers.EmailField(), required=False)
+
+
+class HostContactMutationResponseSerializer(serializers.Serializer):
+    added = serializers.ListField(child=serializers.EmailField(), required=False)
+    already_exists = serializers.ListField(child=serializers.EmailField(), required=False)
+    removed = serializers.ListField(child=serializers.EmailField(), required=False)
+    not_found = serializers.ListField(child=serializers.EmailField(), required=False)
+    error = serializers.CharField(required=False)
+
+
+class DhcpHostSerializer(serializers.Serializer):
+    host__name = serializers.CharField()
+    ipaddress = serializers.IPAddressField()
+    macaddress = serializers.CharField()
+    host__zone__name = serializers.CharField(allow_null=True, required=False)
+
+
+class DhcpV6HostByV4Serializer(serializers.Serializer):
+    host__name = serializers.CharField()
+    host__zone__name = serializers.CharField(allow_null=True, required=False)
+    ipaddress = serializers.IPAddressField(protocol="IPv6")
+    macaddress = serializers.CharField()
 
 
 class HostCommunityMappingSerializer(serializers.ModelSerializer):
@@ -580,6 +613,8 @@ class NetworkExcludedRangeSerializer(ValidationMixin, serializers.ModelSerialize
 
 
 class NetGroupRegexPermissionSerializer(ValidationMixin, serializers.ModelSerializer):
+    range = serializers.CharField()
+
     class Meta:
         model = NetGroupRegexPermission
         fields = '__all__'
@@ -640,6 +675,11 @@ class ReverseZoneDelegationSerializer(BaseZoneDelegationSerializer):
 
     class Meta(BaseZoneSerializer.Meta):
         model = ReverseZoneDelegation
+
+
+class ForwardZoneByHostnameSerializer(serializers.Serializer):
+    zone = ForwardZoneSerializer(required=False)
+    delegation = ForwardZoneDelegationSerializer(required=False)
 
 
 class GroupSerializer(serializers.ModelSerializer):
@@ -817,6 +857,7 @@ class NetworkPolicyAttributeSerializer(serializers.ModelSerializer):
 
 
 class NetworkSerializer(ValidationMixin, serializers.ModelSerializer):
+    network = serializers.CharField()
     excluded_ranges = NetworkExcludedRangeSerializer(many=True, read_only=True)
     
     # Expand the entire policy object
@@ -826,4 +867,3 @@ class NetworkSerializer(ValidationMixin, serializers.ModelSerializer):
     class Meta:
         model = Network
         fields = '__all__'
-

--- a/mreg/api/v1/serializers.py
+++ b/mreg/api/v1/serializers.py
@@ -31,7 +31,6 @@ class ValidationMixin:
 
 
 class ErrorResponseSerializer(serializers.Serializer):
-    ERROR = serializers.CharField(required=False)
     error = serializers.CharField(required=False)
 
 

--- a/mreg/api/v1/tests/test_networks.py
+++ b/mreg/api/v1/tests/test_networks.py
@@ -411,7 +411,7 @@ class NetworksTestCase(MregAPITestCase):
         }
         self.assert_post('/networks/', data)
         ret = self.assert_post_and_409('/hosts/', {'name': 'hostcreateconflictfullnetwork.example.org', 'network': data['network']})
-        self.assertEqual(ret.content, b'{"ERROR":"no available IP in network"}')
+        self.assertEqual(ret.content, b'{"error":"no available IP in network"}')
 
     def test_networks_get_random_unused_200_ok(self):
         """GET on /networks/<ip/mask>/random_unused should return 200 ok and data."""

--- a/mreg/api/v1/urls.py
+++ b/mreg/api/v1/urls.py
@@ -11,7 +11,7 @@ urlpatterns = [
      path('cnames/<name>', views.CnameDetail.as_view()),
      path('dhcphosts/ipv4/', views.dhcp_hosts_all_v4),
      path('dhcphosts/ipv6/', views.dhcp_hosts_all_v6),
-     path('dhcphosts/ipv6byipv4/<ip>/<range>', views.DhcpHostsV4ByV6.as_view()),
+     path('dhcphosts/ipv6byipv4/<ip>/<range>', views.DhcpHostsV4ByV6Range.as_view()),
      path('dhcphosts/ipv6byipv4/', views.DhcpHostsV4ByV6.as_view()),
      path('dhcphosts/<ip>/<range>', views.dhcp_hosts_by_range),
      path('hinfos/', views.HinfoList.as_view()),

--- a/mreg/api/v1/views.py
+++ b/mreg/api/v1/views.py
@@ -383,21 +383,21 @@ class HostList(HostPermissionsListCreateAPIView):
             community_id = request.data.pop("network_community")
             community = Community.objects.filter(id=community_id).first()
             if not community:
-                content = {"ERROR": f"Community '{community_id}' not found"}
+                content = {"error": f"Community '{community_id}' not found"}
                 return Response(content, status=status.HTTP_404_NOT_FOUND)
 
         if "name" in request.data:
             if self.queryset.filter(name=request.data["name"]).exists():
-                content = {"ERROR": "name already in use"}
+                content = {"error": "name already in use"}
                 return Response(content, status=status.HTTP_409_CONFLICT)
 
         if "ipaddress" in request.data and "network" in request.data:
-            content = {"ERROR": "'ipaddress' and 'network' is mutually exclusive"}
+            content = {"error": "'ipaddress' and 'network' is mutually exclusive"}
             return Response(content, status=status.HTTP_400_BAD_REQUEST)
 
         if "allocation_method" in request.data and "network" not in request.data:
             return Response(
-                {"ERROR": "allocation_method is only allowed with 'network'"},
+                {"error": "allocation_method is only allowed with 'network'"},
                 status=status.HTTP_400_BAD_REQUEST)
 
         # request.data is immutable
@@ -414,12 +414,12 @@ class HostList(HostPermissionsListCreateAPIView):
             try:
                 ipaddress.ip_network(network_key)
             except ValueError as error:
-                content = {"ERROR": str(error)}
+                content = {"error": str(error)}
                 return Response(content, status=status.HTTP_400_BAD_REQUEST)
 
             network = Network.objects.filter(network=network_key).first()
             if not network:
-                content = {"ERROR": "no such network"}
+                content = {"error": "no such network"}
                 return Response(content, status=status.HTTP_404_NOT_FOUND)
 
             try:
@@ -429,7 +429,7 @@ class HostList(HostPermissionsListCreateAPIView):
                 request_ip_allocator = IPAllocationMethod(allocation_key.lower())
             except ValueError:
                 options = [method.value for method in IPAllocationMethod]
-                content = {"ERROR": f"allocation_method must be one of {', '.join(options)}"}
+                content = {"error": f"allocation_method must be one of {', '.join(options)}"}
                 return Response(content, status=status.HTTP_400_BAD_REQUEST)
 
             if request_ip_allocator == IPAllocationMethod.RANDOM:
@@ -438,7 +438,7 @@ class HostList(HostPermissionsListCreateAPIView):
                 ip = network.get_first_unused()
 
             if not ip:
-                content = {"ERROR": "no available IP in network"}
+                content = {"error": "no available IP in network"}
                 return Response(content, status=status.HTTP_409_CONFLICT)
 
             hostdata["ipaddress"] = ip
@@ -472,7 +472,7 @@ class HostList(HostPermissionsListCreateAPIView):
                     )
         else:
             if community:
-                content = {"ERROR": "Unable to assign community to host as it has no IP address"}
+                content = {"error": "Unable to assign community to host as it has no IP address"}
                 return Response(content, status=status.HTTP_406_NOT_ACCEPTABLE)
 
             host = Host()
@@ -506,7 +506,7 @@ class HostDetail(HostPermissionsUpdateDestroy,
     def patch(self, request, *args, **kwargs):
         if "name" in request.data:
             if self.get_queryset().filter(name=request.data["name"]).exists():
-                content = {"ERROR": "name already in use"}
+                content = {"error": "name already in use"}
                 return Response(content, status=status.HTTP_409_CONFLICT)
 
         return super().patch(request, *args, **kwargs)
@@ -667,7 +667,7 @@ class IpaddressDetail(HostPermissionsUpdateDestroy, MregRetrieveUpdateDestroyAPI
                 network = Network.objects.get(network__net_contains=new_ip)
             except Network.DoesNotExist:
                 return Response(
-                    {"ERROR": "No network found for the new IP address, cannot update due to community membership"},
+                    {"error": "No network found for the new IP address, cannot update due to community membership"},
                     status=status.HTTP_404_NOT_FOUND,
                 )
             
@@ -679,7 +679,7 @@ class IpaddressDetail(HostPermissionsUpdateDestroy, MregRetrieveUpdateDestroyAPI
 
             if not network_match:
                 return Response(
-                    {"ERROR": "Cannot switch network membership for due to community membership."},
+                    {"error": "Cannot switch network membership for due to community membership."},
                     status=status.HTTP_409_CONFLICT,
                 )
 
@@ -910,7 +910,7 @@ def _overlap_check(range, exclude=None):
     if overlap:
         info = ", ".join(map(str, overlap))
         return Response(
-            {"ERROR": "Network overlaps with: {}".format(info)},
+            {"error": "Network overlaps with: {}".format(info)},
             status=status.HTTP_409_CONFLICT,
         )
 
@@ -971,7 +971,7 @@ class NetworkDetail(MregRetrieveUpdateDestroyAPIView):
                     policy = NetworkPolicy.objects.get(id=policy_id)
                 except NetworkPolicy.DoesNotExist:
                     return Response(
-                        {"ERROR": "No such policy"},
+                        {"error": "No such policy"},
                         status=status.HTTP_404_NOT_FOUND,
                     )
                 policy.can_be_used_with_communities_or_raise()
@@ -985,7 +985,7 @@ class NetworkDetail(MregRetrieveUpdateDestroyAPIView):
         network = self.get_object()
         if network.used_addresses:
             return Response(
-                {"ERROR": "Network contains IP addresses that are in use"},
+                {"error": "Network contains IP addresses that are in use"},
                 status=status.HTTP_409_CONFLICT,
             )
 
@@ -1075,7 +1075,7 @@ def network_first_unused(request, *args, **kwargs):
     if ip:
         return Response(ip, status=status.HTTP_200_OK)
     else:
-        content = {"ERROR": "No available IPs"}
+        content = {"error": "No available IPs"}
         return Response(content, status=status.HTTP_404_NOT_FOUND)
 
 
@@ -1093,7 +1093,7 @@ def network_random_unused(request, *args, **kwargs):
     if ip:
         return Response(ip, status=status.HTTP_200_OK)
     else:
-        content = {"ERROR": "No available IPs"}
+        content = {"error": "No available IPs"}
         return Response(content, status=status.HTTP_404_NOT_FOUND)
 
 

--- a/mreg/api/v1/views.py
+++ b/mreg/api/v1/views.py
@@ -91,6 +91,16 @@ STRING_LIST_MAP_SCHEMA = {
     },
 }
 
+IP_ADDRESS_STRING_SCHEMA = {
+    "type": "string",
+    "description": "IPv4 or IPv6 address.",
+    "examples": ["192.0.2.10", "2001:db8::10"],
+}
+
+IP_ADDRESS_LIST_SCHEMA = {
+    "type": "array",
+    "items": IP_ADDRESS_STRING_SCHEMA,
+}
 
 class JSONContentTypeMixin:
     """A view mixin that requires POST, PUT, PATCH and DELETE operations to this view have a JSON content type.
@@ -1042,7 +1052,7 @@ def network_by_ip(request, *args, **kwargs):
 @extend_schema(
     parameters=[OpenApiParameter("network", OpenApiTypes.STR, OpenApiParameter.PATH)],
     responses={
-        status.HTTP_200_OK: OpenApiTypes.STR,
+        status.HTTP_200_OK: IP_ADDRESS_STRING_SCHEMA,
         status.HTTP_404_NOT_FOUND: ErrorResponseSerializer,
     },
 )
@@ -1059,7 +1069,7 @@ def network_first_unused(request, *args, **kwargs):
 @extend_schema(
     parameters=[OpenApiParameter("network", OpenApiTypes.STR, OpenApiParameter.PATH)],
     responses={
-        status.HTTP_200_OK: OpenApiTypes.STR,
+        status.HTTP_200_OK: IP_ADDRESS_STRING_SCHEMA,
         status.HTTP_404_NOT_FOUND: ErrorResponseSerializer,
     },
 )
@@ -1075,7 +1085,7 @@ def network_random_unused(request, *args, **kwargs):
 
 @extend_schema(
     parameters=[OpenApiParameter("network", OpenApiTypes.STR, OpenApiParameter.PATH)],
-    responses={status.HTTP_200_OK: list[str]},
+    responses={status.HTTP_200_OK: IP_ADDRESS_LIST_SCHEMA},
 )
 @api_view()
 def network_ptroverride_list(request, *args, **kwargs):
@@ -1102,7 +1112,7 @@ def network_ptroverride_host_list(request, *args, **kwargs):
 
 @extend_schema(
     parameters=[OpenApiParameter("network", OpenApiTypes.STR, OpenApiParameter.PATH)],
-    responses={status.HTTP_200_OK: list[str]},
+    responses={status.HTTP_200_OK: IP_ADDRESS_LIST_SCHEMA},
 )
 @api_view()
 def network_reserved_list(request, *args, **kwargs):
@@ -1123,7 +1133,7 @@ def network_used_count(request, *args, **kwargs):
 
 @extend_schema(
     parameters=[OpenApiParameter("network", OpenApiTypes.STR, OpenApiParameter.PATH)],
-    responses={status.HTTP_200_OK: list[str]},
+    responses={status.HTTP_200_OK: IP_ADDRESS_LIST_SCHEMA},
 )
 @api_view()
 def network_used_list(request, *args, **kwargs):
@@ -1158,7 +1168,7 @@ def network_unused_count(request, *args, **kwargs):
 
 @extend_schema(
     parameters=[OpenApiParameter("network", OpenApiTypes.STR, OpenApiParameter.PATH)],
-    responses={status.HTTP_200_OK: list[str]},
+    responses={status.HTTP_200_OK: IP_ADDRESS_LIST_SCHEMA},
 )
 @api_view()
 def network_unused_list(request, *args, **kwargs):

--- a/mreg/api/v1/views.py
+++ b/mreg/api/v1/views.py
@@ -94,7 +94,7 @@ STRING_LIST_MAP_SCHEMA = {
 IP_ADDRESS_STRING_SCHEMA = {
     "type": "string",
     "description": "IPv4 or IPv6 address.",
-    "examples": ["192.0.2.10", "2001:db8::10"],
+    "example": "192.0.2.10",
 }
 
 IP_ADDRESS_LIST_SCHEMA = {

--- a/mreg/api/v1/views.py
+++ b/mreg/api/v1/views.py
@@ -22,6 +22,7 @@ from mreg.models.resource_records import Cname, Loc, Naptr, Srv, Sshfp, Txt, Hin
 from mreg.models.network_policy import Community, HostCommunityMapping, NetworkPolicy
 from mreg.types import IPAllocationMethod
 
+from mreg.api.responses import error_response
 from mreg.api.permissions import (
     IsAuthenticatedAndReadOnly,
     IsGrantedNetGroupRegexPermission,
@@ -383,22 +384,17 @@ class HostList(HostPermissionsListCreateAPIView):
             community_id = request.data.pop("network_community")
             community = Community.objects.filter(id=community_id).first()
             if not community:
-                content = {"error": f"Community '{community_id}' not found"}
-                return Response(content, status=status.HTTP_404_NOT_FOUND)
+                return error_response(f"Community '{community_id}' not found", status.HTTP_404_NOT_FOUND)
 
         if "name" in request.data:
             if self.queryset.filter(name=request.data["name"]).exists():
-                content = {"error": "name already in use"}
-                return Response(content, status=status.HTTP_409_CONFLICT)
+                return error_response("name already in use", status.HTTP_409_CONFLICT)
 
         if "ipaddress" in request.data and "network" in request.data:
-            content = {"error": "'ipaddress' and 'network' is mutually exclusive"}
-            return Response(content, status=status.HTTP_400_BAD_REQUEST)
+            return error_response("'ipaddress' and 'network' is mutually exclusive", status.HTTP_400_BAD_REQUEST)
 
         if "allocation_method" in request.data and "network" not in request.data:
-            return Response(
-                {"error": "allocation_method is only allowed with 'network'"},
-                status=status.HTTP_400_BAD_REQUEST)
+            return error_response("allocation_method is only allowed with 'network'", status.HTTP_400_BAD_REQUEST)
 
         # request.data is immutable
         hostdata = request.data.copy()
@@ -414,13 +410,11 @@ class HostList(HostPermissionsListCreateAPIView):
             try:
                 ipaddress.ip_network(network_key)
             except ValueError as error:
-                content = {"error": str(error)}
-                return Response(content, status=status.HTTP_400_BAD_REQUEST)
+                return error_response(str(error), status.HTTP_400_BAD_REQUEST)
 
             network = Network.objects.filter(network=network_key).first()
             if not network:
-                content = {"error": "no such network"}
-                return Response(content, status=status.HTTP_404_NOT_FOUND)
+                return error_response("no such network", status.HTTP_404_NOT_FOUND)
 
             try:
                 allocation_key = hostdata.pop("allocation_method", IPAllocationMethod.FIRST.value)
@@ -429,8 +423,10 @@ class HostList(HostPermissionsListCreateAPIView):
                 request_ip_allocator = IPAllocationMethod(allocation_key.lower())
             except ValueError:
                 options = [method.value for method in IPAllocationMethod]
-                content = {"error": f"allocation_method must be one of {', '.join(options)}"}
-                return Response(content, status=status.HTTP_400_BAD_REQUEST)
+                return error_response(
+                    f"allocation_method must be one of {', '.join(options)}",
+                    status.HTTP_400_BAD_REQUEST,
+                )
 
             if request_ip_allocator == IPAllocationMethod.RANDOM:
                 ip = network.get_random_unused()
@@ -438,8 +434,7 @@ class HostList(HostPermissionsListCreateAPIView):
                 ip = network.get_first_unused()
 
             if not ip:
-                content = {"error": "no available IP in network"}
-                return Response(content, status=status.HTTP_409_CONFLICT)
+                return error_response("no available IP in network", status.HTTP_409_CONFLICT)
 
             hostdata["ipaddress"] = ip
 
@@ -472,8 +467,10 @@ class HostList(HostPermissionsListCreateAPIView):
                     )
         else:
             if community:
-                content = {"error": "Unable to assign community to host as it has no IP address"}
-                return Response(content, status=status.HTTP_406_NOT_ACCEPTABLE)
+                return error_response(
+                    "Unable to assign community to host as it has no IP address",
+                    status.HTTP_406_NOT_ACCEPTABLE,
+                )
 
             host = Host()
             hostserializer = HostSerializer(host, data=hostdata)
@@ -506,8 +503,7 @@ class HostDetail(HostPermissionsUpdateDestroy,
     def patch(self, request, *args, **kwargs):
         if "name" in request.data:
             if self.get_queryset().filter(name=request.data["name"]).exists():
-                content = {"error": "name already in use"}
-                return Response(content, status=status.HTTP_409_CONFLICT)
+                return error_response("name already in use", status.HTTP_409_CONFLICT)
 
         return super().patch(request, *args, **kwargs)
 
@@ -546,23 +542,17 @@ class HostContactsView(HostPermissionsUpdateDestroy, APIView):
         emails = request.data.get('emails', [])
         
         if not emails:
-            return Response(
-                {"error": "Must provide 'emails' list"},
-                status=status.HTTP_400_BAD_REQUEST
-            )
+            return error_response("Must provide 'emails' list", status.HTTP_400_BAD_REQUEST)
         
         if not isinstance(emails, list):
-            return Response(
-                {"error": "'emails' must be a list"},
-                status=status.HTTP_400_BAD_REQUEST
-            )
+            return error_response("'emails' must be a list", status.HTTP_400_BAD_REQUEST)
 
         result = host.add_contacts(emails)
         
         if result['invalid']:
-            return Response(
-                {"error": f"Invalid email address(es): {', '.join(result['invalid'])}"},
-                status=status.HTTP_400_BAD_REQUEST
+            return error_response(
+                f"Invalid email address(es): {', '.join(result['invalid'])}",
+                status.HTTP_400_BAD_REQUEST,
             )
 
         response_data = {
@@ -591,10 +581,7 @@ class HostContactsView(HostPermissionsUpdateDestroy, APIView):
             )
 
         if not isinstance(emails, list):
-            return Response(
-                {"error": "'emails' must be a list"},
-                status=status.HTTP_400_BAD_REQUEST
-            )
+            return error_response("'emails' must be a list", status.HTTP_400_BAD_REQUEST)
 
         removed = []
         not_found = []
@@ -666,9 +653,9 @@ class IpaddressDetail(HostPermissionsUpdateDestroy, MregRetrieveUpdateDestroyAPI
             try:
                 network = Network.objects.get(network__net_contains=new_ip)
             except Network.DoesNotExist:
-                return Response(
-                    {"error": "No network found for the new IP address, cannot update due to community membership"},
-                    status=status.HTTP_404_NOT_FOUND,
+                return error_response(
+                    "No network found for the new IP address, cannot update due to community membership",
+                    status.HTTP_404_NOT_FOUND,
                 )
             
             network_match = False
@@ -678,9 +665,9 @@ class IpaddressDetail(HostPermissionsUpdateDestroy, MregRetrieveUpdateDestroyAPI
                     break
 
             if not network_match:
-                return Response(
-                    {"error": "Cannot switch network membership for due to community membership."},
-                    status=status.HTTP_409_CONFLICT,
+                return error_response(
+                    "Cannot switch network membership for due to community membership.",
+                    status.HTTP_409_CONFLICT,
                 )
 
         return super().patch(request, *args, **kwargs)
@@ -909,10 +896,7 @@ def _overlap_check(range, exclude=None):
         overlap = overlap.exclude(id=exclude.id)
     if overlap:
         info = ", ".join(map(str, overlap))
-        return Response(
-            {"error": "Network overlaps with: {}".format(info)},
-            status=status.HTTP_409_CONFLICT,
-        )
+        return error_response("Network overlaps with: {}".format(info), status.HTTP_409_CONFLICT)
 
 
 class NetworkList(MregListCreateAPIView):
@@ -970,10 +954,7 @@ class NetworkDetail(MregRetrieveUpdateDestroyAPIView):
                 try:
                     policy = NetworkPolicy.objects.get(id=policy_id)
                 except NetworkPolicy.DoesNotExist:
-                    return Response(
-                        {"error": "No such policy"},
-                        status=status.HTTP_404_NOT_FOUND,
-                    )
+                    return error_response("No such policy", status.HTTP_404_NOT_FOUND)
                 policy.can_be_used_with_communities_or_raise()
                 network.policy = policy
                 
@@ -984,10 +965,7 @@ class NetworkDetail(MregRetrieveUpdateDestroyAPIView):
     def delete(self, request, *args, **kwargs):
         network = self.get_object()
         if network.used_addresses:
-            return Response(
-                {"error": "Network contains IP addresses that are in use"},
-                status=status.HTTP_409_CONFLICT,
-            )
+            return error_response("Network contains IP addresses that are in use", status.HTTP_409_CONFLICT)
 
         self.perform_destroy(network)
         return Response(status=status.HTTP_204_NO_CONTENT)
@@ -1075,8 +1053,7 @@ def network_first_unused(request, *args, **kwargs):
     if ip:
         return Response(ip, status=status.HTTP_200_OK)
     else:
-        content = {"error": "No available IPs"}
-        return Response(content, status=status.HTTP_404_NOT_FOUND)
+        return error_response("No available IPs", status.HTTP_404_NOT_FOUND)
 
 
 @extend_schema(
@@ -1093,8 +1070,7 @@ def network_random_unused(request, *args, **kwargs):
     if ip:
         return Response(ip, status=status.HTTP_200_OK)
     else:
-        content = {"error": "No available IPs"}
-        return Response(content, status=status.HTTP_404_NOT_FOUND)
+        return error_response("No available IPs", status.HTTP_404_NOT_FOUND)
 
 
 @extend_schema(

--- a/mreg/api/v1/views.py
+++ b/mreg/api/v1/views.py
@@ -14,9 +14,10 @@ from rest_framework.exceptions import MethodNotAllowed, ParseError, UnsupportedM
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from drf_spectacular.utils import OpenApiParameter, OpenApiTypes, extend_schema
 from mreg.models.base import NameServer, History
 from mreg.models.host import Host, Ipaddress, PtrOverride
-from mreg.models.network import Network, NetGroupRegexPermission
+from mreg.models.network import Network, NetGroupRegexPermission, NetworkExcludedRange
 from mreg.models.resource_records import Cname, Loc, Naptr, Srv, Sshfp, Txt, Hinfo, Mx
 from mreg.models.network_policy import Community, HostCommunityMapping, NetworkPolicy
 from mreg.types import IPAllocationMethod
@@ -50,8 +51,13 @@ from .filters import (
 from .history import HistoryLog
 from .serializers import (
     CnameSerializer,
+    DhcpHostSerializer,
+    DhcpV6HostByV4Serializer,
+    ErrorResponseSerializer,
     HinfoSerializer,
     HistorySerializer,
+    HostContactMutationResponseSerializer,
+    HostContactMutationSerializer,
     HostContactSerializer,
     HostSerializer,
     IpaddressSerializer,
@@ -69,6 +75,21 @@ from .serializers import (
 )
 
 from mreg.mixins import LowerCaseLookupMixin
+
+
+STRING_MAP_SCHEMA = {
+    "type": "object",
+    "additionalProperties": {"type": "string"},
+}
+
+STRING_LIST_MAP_SCHEMA = {
+    "type": "object",
+    "additionalProperties": {
+        "type": "array",
+        "items": {"type": "string"},
+    },
+}
+
 
 class JSONContentTypeMixin:
     """A view mixin that requires POST, PUT, PATCH and DELETE operations to this view have a JSON content type.
@@ -504,12 +525,21 @@ class HostContactsView(HostPermissionsUpdateDestroy, APIView):
         """Get the host object by name."""
         return get_object_or_404(Host, name=name.lower())
 
+    @extend_schema(
+        parameters=[OpenApiParameter("name", OpenApiTypes.STR, OpenApiParameter.PATH)],
+        responses={status.HTTP_200_OK: HostContactSerializer(many=True)},
+    )
     def get(self, request, name):
         """List all contacts for the host."""
         host = self.get_host(name)
         serializer = HostContactSerializer(host.contacts.all(), many=True)
         return Response(serializer.data)
 
+    @extend_schema(
+        parameters=[OpenApiParameter("name", OpenApiTypes.STR, OpenApiParameter.PATH)],
+        request=HostContactMutationSerializer,
+        responses={status.HTTP_200_OK: HostContactMutationResponseSerializer},
+    )
     def post(self, request, name):
         """Add one or more contacts to the host."""
         host = self.get_host(name)
@@ -541,6 +571,11 @@ class HostContactsView(HostPermissionsUpdateDestroy, APIView):
         }
         return Response(response_data, status=status.HTTP_200_OK)
 
+    @extend_schema(
+        parameters=[OpenApiParameter("name", OpenApiTypes.STR, OpenApiParameter.PATH)],
+        request=HostContactMutationSerializer,
+        responses={status.HTTP_200_OK: HostContactMutationResponseSerializer},
+    )
     def delete(self, request, name):
         """Remove one or more contacts from the host, or clear all if no emails provided."""
         host = self.get_host(name)
@@ -980,6 +1015,8 @@ class NetworkExcludedRangeList(MregListCreateAPIView):
         Applies filtering to the queryset
         :return: filtered list of network excludes
         """
+        if "network" not in self.kwargs:
+            return NetworkExcludedRange.objects.none()
         qs = get_object_or_404(
             Network, network=self.kwargs["network"]
         ).excluded_ranges.all()
@@ -1003,10 +1040,16 @@ class NetworkExcludedRangeDetail(MregRetrieveUpdateDestroyAPIView):
     lookup_field = "pk"
 
     def get_queryset(self):
+        if "network" not in self.kwargs:
+            return NetworkExcludedRange.objects.none()
         network = get_object_or_404(Network, network=self.kwargs["network"])
         return network.excluded_ranges.all()
 
 
+@extend_schema(
+    parameters=[OpenApiParameter("ip", OpenApiTypes.STR, OpenApiParameter.PATH)],
+    responses={status.HTTP_200_OK: NetworkSerializer},
+)
 @api_view()
 def network_by_ip(request, *args, **kwargs):
     try:
@@ -1018,6 +1061,13 @@ def network_by_ip(request, *args, **kwargs):
     return Response(serializer.data, status=status.HTTP_200_OK)
 
 
+@extend_schema(
+    parameters=[OpenApiParameter("network", OpenApiTypes.STR, OpenApiParameter.PATH)],
+    responses={
+        status.HTTP_200_OK: OpenApiTypes.STR,
+        status.HTTP_404_NOT_FOUND: ErrorResponseSerializer,
+    },
+)
 @api_view()
 def network_first_unused(request, *args, **kwargs):
     network = get_object_or_404(Network, network=kwargs["network"])
@@ -1029,6 +1079,13 @@ def network_first_unused(request, *args, **kwargs):
         return Response(content, status=status.HTTP_404_NOT_FOUND)
 
 
+@extend_schema(
+    parameters=[OpenApiParameter("network", OpenApiTypes.STR, OpenApiParameter.PATH)],
+    responses={
+        status.HTTP_200_OK: OpenApiTypes.STR,
+        status.HTTP_404_NOT_FOUND: ErrorResponseSerializer,
+    },
+)
 @api_view()
 def network_random_unused(request, *args, **kwargs):
     network = get_object_or_404(Network, network=kwargs["network"])
@@ -1040,6 +1097,10 @@ def network_random_unused(request, *args, **kwargs):
         return Response(content, status=status.HTTP_404_NOT_FOUND)
 
 
+@extend_schema(
+    parameters=[OpenApiParameter("network", OpenApiTypes.STR, OpenApiParameter.PATH)],
+    responses={status.HTTP_200_OK: list[str]},
+)
 @api_view()
 def network_ptroverride_list(request, *args, **kwargs):
     network = get_object_or_404(Network, network=kwargs["network"])
@@ -1048,6 +1109,10 @@ def network_ptroverride_list(request, *args, **kwargs):
     return Response(ptr_list, status=status.HTTP_200_OK)
 
 
+@extend_schema(
+    parameters=[OpenApiParameter("network", OpenApiTypes.STR, OpenApiParameter.PATH)],
+    responses={status.HTTP_200_OK: STRING_MAP_SCHEMA},
+)
 @api_view()
 def network_ptroverride_host_list(request, *args, **kwargs):
     network = get_object_or_404(Network, network=kwargs["network"])
@@ -1059,6 +1124,10 @@ def network_ptroverride_host_list(request, *args, **kwargs):
     return Response(ret, status=status.HTTP_200_OK)
 
 
+@extend_schema(
+    parameters=[OpenApiParameter("network", OpenApiTypes.STR, OpenApiParameter.PATH)],
+    responses={status.HTTP_200_OK: list[str]},
+)
 @api_view()
 def network_reserved_list(request, *args, **kwargs):
     network = get_object_or_404(Network, network=kwargs["network"])
@@ -1066,12 +1135,20 @@ def network_reserved_list(request, *args, **kwargs):
     return Response(reserved, status=status.HTTP_200_OK)
 
 
+@extend_schema(
+    parameters=[OpenApiParameter("network", OpenApiTypes.STR, OpenApiParameter.PATH)],
+    responses={status.HTTP_200_OK: OpenApiTypes.INT},
+)
 @api_view()
 def network_used_count(request, *args, **kwargs):
     network = get_object_or_404(Network, network=kwargs["network"])
     return Response(len(network.used_addresses), status=status.HTTP_200_OK)
 
 
+@extend_schema(
+    parameters=[OpenApiParameter("network", OpenApiTypes.STR, OpenApiParameter.PATH)],
+    responses={status.HTTP_200_OK: list[str]},
+)
 @api_view()
 def network_used_list(request, *args, **kwargs):
     network = get_object_or_404(Network, network=kwargs["network"])
@@ -1079,6 +1156,10 @@ def network_used_list(request, *args, **kwargs):
     return Response(used_ipaddresses, status=status.HTTP_200_OK)
 
 
+@extend_schema(
+    parameters=[OpenApiParameter("network", OpenApiTypes.STR, OpenApiParameter.PATH)],
+    responses={status.HTTP_200_OK: STRING_LIST_MAP_SCHEMA},
+)
 @api_view()
 def network_used_host_list(request, *args, **kwargs):
     network = get_object_or_404(Network, network=kwargs["network"])
@@ -1089,12 +1170,20 @@ def network_used_host_list(request, *args, **kwargs):
     return Response(ret, status=status.HTTP_200_OK)
 
 
+@extend_schema(
+    parameters=[OpenApiParameter("network", OpenApiTypes.STR, OpenApiParameter.PATH)],
+    responses={status.HTTP_200_OK: OpenApiTypes.INT},
+)
 @api_view()
 def network_unused_count(request, *args, **kwargs):
     network = get_object_or_404(Network, network=kwargs["network"])
     return Response(network.unused_count, status=status.HTTP_200_OK)
 
 
+@extend_schema(
+    parameters=[OpenApiParameter("network", OpenApiTypes.STR, OpenApiParameter.PATH)],
+    responses={status.HTTP_200_OK: list[str]},
+)
 @api_view()
 def network_unused_list(request, *args, **kwargs):
     network = get_object_or_404(Network, network=kwargs["network"])
@@ -1179,16 +1268,25 @@ def _dhcphosts_by_range(iprange):
     return Response(ips)
 
 
+@extend_schema(responses={status.HTTP_200_OK: DhcpHostSerializer(many=True)})
 @api_view()
 def dhcp_hosts_all_v4(request, *args, **kwargs):
     return _dhcphosts_by_range("0.0.0.0/0")
 
 
+@extend_schema(responses={status.HTTP_200_OK: DhcpHostSerializer(many=True)})
 @api_view()
 def dhcp_hosts_all_v6(request, *args, **kwargs):
     return _dhcphosts_by_range("::/0")
 
 
+@extend_schema(
+    parameters=[
+        OpenApiParameter("ip", OpenApiTypes.STR, OpenApiParameter.PATH),
+        OpenApiParameter("range", OpenApiTypes.INT, OpenApiParameter.PATH),
+    ],
+    responses={status.HTTP_200_OK: DhcpHostSerializer(many=True)},
+)
 @api_view()
 def dhcp_hosts_by_range(request, *args, **kwargs):
     return _dhcphosts_by_range(_get_iprange(kwargs))
@@ -1225,7 +1323,7 @@ def _dhcpv6_hosts_by_ipv4(iprange):
     return Response(ret)
 
 
-class DhcpHostsV4ByV6(APIView):
+class DhcpHostsV4ByV6Base(APIView):
     renderer_classes = (JSONRenderer,)
 
     def get(self, request, *args, **kwargs):
@@ -1234,3 +1332,25 @@ class DhcpHostsV4ByV6(APIView):
         else:
             iprange = "0.0.0.0/0"
         return _dhcpv6_hosts_by_ipv4(iprange)
+
+
+class DhcpHostsV4ByV6(DhcpHostsV4ByV6Base):
+    @extend_schema(
+        operation_id="api_v1_dhcphosts_ipv6byipv4_list",
+        responses={status.HTTP_200_OK: DhcpV6HostByV4Serializer(many=True)},
+    )
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
+
+
+class DhcpHostsV4ByV6Range(DhcpHostsV4ByV6Base):
+    @extend_schema(
+        operation_id="api_v1_dhcphosts_ipv6byipv4_by_range_list",
+        parameters=[
+            OpenApiParameter("ip", OpenApiTypes.STR, OpenApiParameter.PATH),
+            OpenApiParameter("range", OpenApiTypes.INT, OpenApiParameter.PATH),
+        ],
+        responses={status.HTTP_200_OK: DhcpV6HostByV4Serializer(many=True)},
+    )
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)

--- a/mreg/api/v1/views_bacnet.py
+++ b/mreg/api/v1/views_bacnet.py
@@ -44,10 +44,10 @@ class BACnetIDList(MregListCreateAPIView):
             # if a host was supplied and that host already has a BACnet ID, return 409 conflict
             # instead of the default 400 bad request
             if host and hasattr(host, "bacnetid"):
-                content = {"ERROR": "The host already has a BACnet ID."}
+                content = {"error": "The host already has a BACnet ID."}
                 return Response(content, status=status.HTTP_409_CONFLICT)
         except Host.DoesNotExist:
-            content = {"ERROR": "The host does not exist."}
+            content = {"error": "The host does not exist."}
             return Response(content, status=status.HTTP_400_BAD_REQUEST)
 
         # validate the data

--- a/mreg/api/v1/views_bacnet.py
+++ b/mreg/api/v1/views_bacnet.py
@@ -1,6 +1,7 @@
 from rest_framework import status
 from rest_framework.response import Response
 
+from mreg.api.responses import error_response
 from mreg.api.v1.views import (
     MregListCreateAPIView,
     MregRetrieveUpdateDestroyAPIView,
@@ -44,11 +45,9 @@ class BACnetIDList(MregListCreateAPIView):
             # if a host was supplied and that host already has a BACnet ID, return 409 conflict
             # instead of the default 400 bad request
             if host and hasattr(host, "bacnetid"):
-                content = {"error": "The host already has a BACnet ID."}
-                return Response(content, status=status.HTTP_409_CONFLICT)
+                return error_response("The host already has a BACnet ID.", status.HTTP_409_CONFLICT)
         except Host.DoesNotExist:
-            content = {"error": "The host does not exist."}
-            return Response(content, status=status.HTTP_400_BAD_REQUEST)
+            return error_response("The host does not exist.", status.HTTP_400_BAD_REQUEST)
 
         # validate the data
         obj = BACnetID()

--- a/mreg/api/v1/views_hostgroups.py
+++ b/mreg/api/v1/views_hostgroups.py
@@ -144,7 +144,8 @@ class HostGroupGroupsDetail(HostGroupM2MDetail):
 
     serializer_class = serializers.HostGroupSerializer
     m2m_field = 'groups'
-    lookup_field = 'group'
+    lookup_field = 'name'
+    lookup_url_kwarg = 'group'
 
 
 class HostGroupHostsList(HostGroupM2MList):
@@ -175,7 +176,8 @@ class HostGroupHostsDetail(HostGroupM2MDetail):
 
     serializer_class = serializers.GroupSerializer
     m2m_field = 'hosts'
-    lookup_field = 'host'
+    lookup_field = 'name'
+    lookup_url_kwarg = 'host'
 
 
 class HostGroupOwnersList(HostGroupM2MList):
@@ -207,4 +209,5 @@ class HostGroupOwnersDetail(HostGroupM2MDetail):
 
     serializer_class = serializers.GroupSerializer
     m2m_field = 'owners'
-    lookup_field = 'owner'
+    lookup_field = 'name'
+    lookup_url_kwarg = 'owner'

--- a/mreg/api/v1/views_hostgroups.py
+++ b/mreg/api/v1/views_hostgroups.py
@@ -83,7 +83,7 @@ class HostGroupList(HostGroupLogMixin, LowerCaseLookupMixin, MregListCreateAPIVi
 
     def post(self, request, *args, **kwargs):
         if self.get_object_from_request(request):
-            content = {'ERROR': 'hostgroup name already in use'}
+            content = {'error': 'hostgroup name already in use'}
             return Response(content, status=status.HTTP_409_CONFLICT)
         return super().post(request, *args, **kwargs)
 

--- a/mreg/api/v1/views_hostgroups.py
+++ b/mreg/api/v1/views_hostgroups.py
@@ -3,8 +3,8 @@ from django.contrib.auth.models import Group
 from django.db.models import Prefetch
 
 from rest_framework import status
-from rest_framework.response import Response
 
+from mreg.api.responses import error_response
 from mreg.api.permissions import (HostGroupPermission,
                                   IsSuperOrGroupAdminOrReadOnly)
 from mreg.models.host import Host, HostGroup
@@ -83,8 +83,7 @@ class HostGroupList(HostGroupLogMixin, LowerCaseLookupMixin, MregListCreateAPIVi
 
     def post(self, request, *args, **kwargs):
         if self.get_object_from_request(request):
-            content = {'error': 'hostgroup name already in use'}
-            return Response(content, status=status.HTTP_409_CONFLICT)
+            return error_response('hostgroup name already in use', status.HTTP_409_CONFLICT)
         return super().post(request, *args, **kwargs)
 
 

--- a/mreg/api/v1/views_labels.py
+++ b/mreg/api/v1/views_labels.py
@@ -20,7 +20,7 @@ class LabelList(MregListCreateAPIView, LowerCaseLookupMixin):
 
     def post(self, request, *args, **kwargs):        
         if self.get_object_from_request(request):
-            content = {"ERROR": "Label name already in use"}
+            content = {"error": "Label name already in use"}
             return Response(content, status=status.HTTP_409_CONFLICT)
         return super().post(request, *args, **kwargs)
 

--- a/mreg/api/v1/views_labels.py
+++ b/mreg/api/v1/views_labels.py
@@ -1,7 +1,7 @@
 from rest_framework import status
-from rest_framework.response import Response
 
 from .views import MregListCreateAPIView, MregRetrieveUpdateDestroyAPIView
+from mreg.api.responses import error_response
 from mreg.models.base import Label
 from mreg.api.permissions import IsSuperOrAdminOrReadOnly
 
@@ -20,8 +20,7 @@ class LabelList(MregListCreateAPIView, LowerCaseLookupMixin):
 
     def post(self, request, *args, **kwargs):        
         if self.get_object_from_request(request):
-            content = {"error": "Label name already in use"}
-            return Response(content, status=status.HTTP_409_CONFLICT)
+            return error_response("Label name already in use", status.HTTP_409_CONFLICT)
         return super().post(request, *args, **kwargs)
 
 

--- a/mreg/api/v1/views_m2m.py
+++ b/mreg/api/v1/views_m2m.py
@@ -76,7 +76,7 @@ class M2MList:
         if "name" in request.data:
             name = request.data['name']
             if qs.filter(name=name).exists():
-                content = {'ERROR': f'{name} already in {self.m2m_field}'}
+                content = {'error': f'{name} already in {self.m2m_field}'}
                 return Response(content, status=status.HTTP_409_CONFLICT)
             if self.m2m_create_if_missing:
                 instance, created = self.m2m_object.objects.get_or_create(name=name)
@@ -84,11 +84,11 @@ class M2MList:
                 try:
                     instance = self.m2m_object.objects.get(name=name)
                 except self.m2m_object.DoesNotExist:
-                    content = {'ERROR': f'"{name}" does not exist'}
+                    content = {'error': f'"{name}" does not exist'}
                     return Response(content, status=status.HTTP_404_NOT_FOUND)
             self.perform_m2m_alteration(self.m2mrelation.add, instance)
             location = request.path + instance.name
             return Response(status=status.HTTP_201_CREATED, headers={'Location': location})
         else:
-            content = {'ERROR': 'No name provided'}
+            content = {'error': 'No name provided'}
             return Response(content, status=status.HTTP_400_BAD_REQUEST)

--- a/mreg/api/v1/views_m2m.py
+++ b/mreg/api/v1/views_m2m.py
@@ -31,10 +31,13 @@ class M2MDetail:
 
     def get_object(self):
         queryset = self.filter_queryset(self.get_queryset())
-        obj = get_object_or_404(queryset, name=self.kwargs[self.lookup_field])
+        lookup_url_kwarg = getattr(self, "lookup_url_kwarg", None) or self.lookup_field
+        obj = get_object_or_404(queryset, name=self.kwargs[lookup_url_kwarg])
         return obj
 
     def get_queryset(self):
+        if 'name' not in self.kwargs:
+            return self.cls.objects.none()
         self.object = get_object_or_404(self.cls, name=self.kwargs['name'])
         self.m2mrelation = getattr(self.object, self.m2m_field)
         return self.m2mrelation.all()
@@ -60,8 +63,11 @@ class M2MList:
     m2m_create_if_missing = False
 
     def get_queryset(self):
+        lookup_url_kwarg = getattr(self, "lookup_url_kwarg", None) or self.lookup_field
+        if lookup_url_kwarg not in self.kwargs:
+            return self.cls.objects.none()
         self.object = get_object_or_404(self.cls,
-                                        name=self.kwargs[self.lookup_field])
+                                        name=self.kwargs[lookup_url_kwarg])
         self.m2mrelation = getattr(self.object, self.m2m_field)
         return self.m2mrelation.all().order_by('name')
 

--- a/mreg/api/v1/views_m2m.py
+++ b/mreg/api/v1/views_m2m.py
@@ -4,6 +4,8 @@ from rest_framework import status
 from rest_framework.exceptions import MethodNotAllowed
 from rest_framework.response import Response
 
+from mreg.api.responses import error_response
+
 
 class M2MPermissions:
 
@@ -76,19 +78,16 @@ class M2MList:
         if "name" in request.data:
             name = request.data['name']
             if qs.filter(name=name).exists():
-                content = {'error': f'{name} already in {self.m2m_field}'}
-                return Response(content, status=status.HTTP_409_CONFLICT)
+                return error_response(f'{name} already in {self.m2m_field}', status.HTTP_409_CONFLICT)
             if self.m2m_create_if_missing:
                 instance, created = self.m2m_object.objects.get_or_create(name=name)
             else:
                 try:
                     instance = self.m2m_object.objects.get(name=name)
                 except self.m2m_object.DoesNotExist:
-                    content = {'error': f'"{name}" does not exist'}
-                    return Response(content, status=status.HTTP_404_NOT_FOUND)
+                    return error_response(f'"{name}" does not exist', status.HTTP_404_NOT_FOUND)
             self.perform_m2m_alteration(self.m2mrelation.add, instance)
             location = request.path + instance.name
             return Response(status=status.HTTP_201_CREATED, headers={'Location': location})
         else:
-            content = {'error': 'No name provided'}
-            return Response(content, status=status.HTTP_400_BAD_REQUEST)
+            return error_response('No name provided', status.HTTP_400_BAD_REQUEST)

--- a/mreg/api/v1/views_network_policy.py
+++ b/mreg/api/v1/views_network_policy.py
@@ -220,6 +220,8 @@ class NetworkCommunityHostList(HostInCommunityMixin, generics.ListCreateAPIView)
     permission_classes = (IsGrantedNetGroupRegexPermission | IsSuperOrNetworkAdminMember,)
 
     def get_queryset(self):
+        if "network" not in self.kwargs or "cpk" not in self.kwargs:
+            return Host.objects.none()
         _, community = self.get_policy_and_community()
         return HostFilterSet(
             data=self.request.GET, queryset=Host.objects.filter(communities__in=[community]).order_by("id").distinct()
@@ -261,6 +263,8 @@ class NetworkCommunityHostDetail(HostInCommunityMixin, generics.RetrieveDestroyA
     permission_classes = (IsGrantedNetGroupRegexPermission | IsSuperOrNetworkAdminMember,)
 
     def get_queryset(self):
+        if "network" not in self.kwargs or "cpk" not in self.kwargs:
+            return Host.objects.none()
         _, community = self.get_policy_and_community()
         return HostFilterSet(
             data=self.request.GET, queryset=Host.objects.filter(communities__in=[community]).order_by("id").distinct()

--- a/mreg/api/v1/views_zones.py
+++ b/mreg/api/v1/views_zones.py
@@ -32,9 +32,7 @@ from .filters import (ForwardZoneFilterSet, ReverseZoneFilterSet)
 ZONE_FILE_TEXT_SCHEMA = {
     "type": "string",
     "description": "DNS zone file in BIND-style text format.",
-    "examples": [
-        "$ORIGIN example.org.\n@ 3600 IN SOA ns1.example.org. hostmaster.example.org. 1 3600 900 604800 3600\n"
-    ],
+    "example": "$ORIGIN example.org.\n@ 3600 IN SOA ns1.example.org. hostmaster.example.org. 1 3600 900 604800 3600\n",
 }
 
 

--- a/mreg/api/v1/views_zones.py
+++ b/mreg/api/v1/views_zones.py
@@ -29,6 +29,15 @@ from .zonefile import ZoneFile
 from .filters import (ForwardZoneFilterSet, ReverseZoneFilterSet)
 
 
+ZONE_FILE_TEXT_SCHEMA = {
+    "type": "string",
+    "description": "DNS zone file in BIND-style text format.",
+    "examples": [
+        "$ORIGIN example.org.\n@ 3600 IN SOA ns1.example.org. hostmaster.example.org. 1 3600 900 604800 3600\n"
+    ],
+}
+
+
 def _update_parent_zone(qs, zonename):
     """Try to figure if the zone name is a sub zone, and if so, set
        the parent zone's updated attribute to True to make sure it
@@ -379,7 +388,7 @@ class PlainTextRenderer(renderers.TemplateHTMLRenderer):
         OpenApiParameter("name", OpenApiTypes.STR, OpenApiParameter.PATH),
         OpenApiParameter("excludePrivate", OpenApiTypes.BOOL, OpenApiParameter.QUERY, required=False),
     ],
-    responses={(status.HTTP_200_OK, "text/plain"): OpenApiTypes.STR},
+    responses={(status.HTTP_200_OK, "text/plain"): ZONE_FILE_TEXT_SCHEMA},
 )
 @api_view()
 @renderer_classes([PlainTextRenderer])

--- a/mreg/api/v1/views_zones.py
+++ b/mreg/api/v1/views_zones.py
@@ -10,6 +10,7 @@ from rest_framework.decorators import (api_view, renderer_classes)
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
+from drf_spectacular.utils import OpenApiParameter, OpenApiTypes, extend_schema
 
 from mreg.models.base import NameServer
 from mreg.models.host import Host
@@ -19,7 +20,7 @@ from mreg.mixins import LowerCaseLookupMixin
 
 from mreg.api.permissions import (IsSuperGroupMember, IsAuthenticatedAndReadOnly)
 
-from .serializers import (ForwardZoneDelegationSerializer, ForwardZoneSerializer,
+from .serializers import (ForwardZoneByHostnameSerializer, ForwardZoneDelegationSerializer, ForwardZoneSerializer,
                           ReverseZoneDelegationSerializer, ReverseZoneSerializer)
 from .views import (MregRetrieveUpdateDestroyAPIView, )
 from .zonefile import ZoneFile
@@ -132,6 +133,8 @@ class ZoneDelegationList(generics.ListCreateAPIView):
     permission_classes = (IsSuperGroupMember | IsAuthenticatedAndReadOnly, )
 
     def get_queryset(self):
+        if self.lookup_field not in self.kwargs:
+            return self.model.objects.none()
         self.parentzone = get_object_or_404(self.model, name=self.kwargs[self.lookup_field])
         self.queryset = self.parentzone.delegations.all().order_by('id')
         return self.filterset(data=self.request.GET, queryset=self.queryset).qs
@@ -330,6 +333,10 @@ class ReverseZoneNameServerDetail(ZoneNameServerDetail):
     serializer_class = ReverseZoneSerializer
 
 
+@extend_schema(
+    parameters=[OpenApiParameter("hostname", OpenApiTypes.STR, OpenApiParameter.PATH)],
+    responses={status.HTTP_200_OK: ForwardZoneByHostnameSerializer},
+)
 @api_view()
 def forward_zone_by_hostname(request, *args, **kwargs):
     """
@@ -367,6 +374,13 @@ class PlainTextRenderer(renderers.TemplateHTMLRenderer):
         return data.encode(self.charset)
 
 
+@extend_schema(
+    parameters=[
+        OpenApiParameter("name", OpenApiTypes.STR, OpenApiParameter.PATH),
+        OpenApiParameter("excludePrivate", OpenApiTypes.BOOL, OpenApiParameter.QUERY, required=False),
+    ],
+    responses={(status.HTTP_200_OK, "text/plain"): OpenApiTypes.STR},
+)
 @api_view()
 @renderer_classes([PlainTextRenderer])
 def zone_file_detail(request, *args, **kwargs):

--- a/mreg/api/v1/views_zones.py
+++ b/mreg/api/v1/views_zones.py
@@ -18,6 +18,7 @@ from mreg.models.zone import ForwardZone, ForwardZoneDelegation, ReverseZone, Re
 
 from mreg.mixins import LowerCaseLookupMixin
 
+from mreg.api.responses import error_response
 from mreg.api.permissions import (IsSuperGroupMember, IsAuthenticatedAndReadOnly)
 
 from .serializers import (ForwardZoneByHostnameSerializer, ForwardZoneDelegationSerializer, ForwardZoneSerializer,
@@ -90,8 +91,7 @@ class ZoneList(generics.ListCreateAPIView):
     def post(self, request: Request, *args, **kwargs):
         qs = self.get_queryset()
         if qs.filter(name=request.data["name"]).exists():
-            content = {'error': 'Zone name already in use'}
-            return Response(content, status=status.HTTP_409_CONFLICT)
+            return error_response('Zone name already in use', status.HTTP_409_CONFLICT)
         # A copy is required since the original is immutable
         nameservers = _get_request_nameservers(request)
         _validate_nameservers(nameservers)
@@ -142,8 +142,7 @@ class ZoneDelegationList(generics.ListCreateAPIView):
     def post(self, request: Request, *args, **kwargs):
         qs = self.get_queryset()
         if qs.filter(name=request.data[self.lookup_field]).exists():
-            content = {'error': 'Zone name already in use'}
-            return Response(content, status=status.HTTP_409_CONFLICT)
+            return error_response('Zone name already in use', status.HTTP_409_CONFLICT)
         nameservers = _get_request_nameservers(request, "nameservers")
         _validate_nameservers(nameservers)
         data = request.data.copy()
@@ -192,19 +191,22 @@ class ZoneDetail(LowerCaseLookupMixin, MregRetrieveUpdateDestroyAPIView):
         query = self.kwargs[self.lookup_field]
 
         if "name" in request.data:
-            content = {'error': 'Not allowed to change name'}
-            return Response(content, status=status.HTTP_403_FORBIDDEN)
+            return error_response('Not allowed to change name', status.HTTP_403_FORBIDDEN)
 
         if "nameservers" in request.data:
-            content = {'error': 'Not allowed to patch nameservers, use /zones/{}/nameservers'.format(query)}
-            return Response(content, status=status.HTTP_403_FORBIDDEN)
+            return error_response(
+                'Not allowed to patch nameservers, use /zones/{}/nameservers'.format(query),
+                status.HTTP_403_FORBIDDEN,
+            )
 
         zone = self.get_object()
         # Check if primary_ns is in the zone's list of nameservers
         if "primary_ns" in request.data:
             if request.data['primary_ns'] not in [nameserver.name for nameserver in zone.nameservers.all()]:
-                content = {'error': "%s is not one of %s's nameservers" % (request.data['primary_ns'], query)}
-                return Response(content, status=status.HTTP_403_FORBIDDEN)
+                return error_response(
+                    "%s is not one of %s's nameservers" % (request.data['primary_ns'], query),
+                    status.HTTP_403_FORBIDDEN,
+                )
         serializer = self.get_serializer(zone, data=request.data, partial=True)
         serializer.is_valid(raise_exception=True)
         self.perform_update(serializer, updated=True)
@@ -216,8 +218,7 @@ class ZoneDetail(LowerCaseLookupMixin, MregRetrieveUpdateDestroyAPIView):
         if isinstance(zone, ForwardZone):
             qs = Host.objects.filter(zone=zone)
             if qs.exists():
-                content = {'error': f'{zone.name} still in use by {qs.count()} hosts'}
-                return Response(content, status=status.HTTP_403_FORBIDDEN)
+                return error_response(f'{zone.name} still in use by {qs.count()} hosts', status.HTTP_403_FORBIDDEN)
         with transaction.atomic():
             zone.remove_nameservers()
             zone.delete()
@@ -267,8 +268,7 @@ class ZoneDelegationDetail(LowerCaseLookupMixin, MregRetrieveUpdateDestroyAPIVie
             self.parentzone.save()
             return super().patch(request, *args, **kwargs)
         else:
-            content = {'error': 'Only allowed to change comment'}
-            return Response(content, status=status.HTTP_403_FORBIDDEN)
+            return error_response('Only allowed to change comment', status.HTTP_403_FORBIDDEN)
 
     def delete(self, request, *args, **kwargs):
         zone = self.get_object()
@@ -312,7 +312,7 @@ class ZoneNameServerDetail(MregRetrieveUpdateDestroyAPIView):
 
     def patch(self, request: Request, *args, **kwargs):
         if 'primary_ns' not in request.data:
-            return Response({'error': 'No nameserver found in body'}, status=status.HTTP_400_BAD_REQUEST)
+            return error_response('No nameserver found in body', status.HTTP_400_BAD_REQUEST)
         zone = self.get_object()
         nameservers = _get_request_nameservers(request)
         _validate_nameservers(nameservers)

--- a/mreg/api/v1/views_zones.py
+++ b/mreg/api/v1/views_zones.py
@@ -90,7 +90,7 @@ class ZoneList(generics.ListCreateAPIView):
     def post(self, request: Request, *args, **kwargs):
         qs = self.get_queryset()
         if qs.filter(name=request.data["name"]).exists():
-            content = {'ERROR': 'Zone name already in use'}
+            content = {'error': 'Zone name already in use'}
             return Response(content, status=status.HTTP_409_CONFLICT)
         # A copy is required since the original is immutable
         nameservers = _get_request_nameservers(request)
@@ -142,7 +142,7 @@ class ZoneDelegationList(generics.ListCreateAPIView):
     def post(self, request: Request, *args, **kwargs):
         qs = self.get_queryset()
         if qs.filter(name=request.data[self.lookup_field]).exists():
-            content = {'ERROR': 'Zone name already in use'}
+            content = {'error': 'Zone name already in use'}
             return Response(content, status=status.HTTP_409_CONFLICT)
         nameservers = _get_request_nameservers(request, "nameservers")
         _validate_nameservers(nameservers)
@@ -192,18 +192,18 @@ class ZoneDetail(LowerCaseLookupMixin, MregRetrieveUpdateDestroyAPIView):
         query = self.kwargs[self.lookup_field]
 
         if "name" in request.data:
-            content = {'ERROR': 'Not allowed to change name'}
+            content = {'error': 'Not allowed to change name'}
             return Response(content, status=status.HTTP_403_FORBIDDEN)
 
         if "nameservers" in request.data:
-            content = {'ERROR': 'Not allowed to patch nameservers, use /zones/{}/nameservers'.format(query)}
+            content = {'error': 'Not allowed to patch nameservers, use /zones/{}/nameservers'.format(query)}
             return Response(content, status=status.HTTP_403_FORBIDDEN)
 
         zone = self.get_object()
         # Check if primary_ns is in the zone's list of nameservers
         if "primary_ns" in request.data:
             if request.data['primary_ns'] not in [nameserver.name for nameserver in zone.nameservers.all()]:
-                content = {'ERROR': "%s is not one of %s's nameservers" % (request.data['primary_ns'], query)}
+                content = {'error': "%s is not one of %s's nameservers" % (request.data['primary_ns'], query)}
                 return Response(content, status=status.HTTP_403_FORBIDDEN)
         serializer = self.get_serializer(zone, data=request.data, partial=True)
         serializer.is_valid(raise_exception=True)
@@ -216,7 +216,7 @@ class ZoneDetail(LowerCaseLookupMixin, MregRetrieveUpdateDestroyAPIView):
         if isinstance(zone, ForwardZone):
             qs = Host.objects.filter(zone=zone)
             if qs.exists():
-                content = {'ERROR': f'{zone.name} still in use by {qs.count()} hosts'}
+                content = {'error': f'{zone.name} still in use by {qs.count()} hosts'}
                 return Response(content, status=status.HTTP_403_FORBIDDEN)
         with transaction.atomic():
             zone.remove_nameservers()
@@ -267,7 +267,7 @@ class ZoneDelegationDetail(LowerCaseLookupMixin, MregRetrieveUpdateDestroyAPIVie
             self.parentzone.save()
             return super().patch(request, *args, **kwargs)
         else:
-            content = {'ERROR': 'Only allowed to change comment'}
+            content = {'error': 'Only allowed to change comment'}
             return Response(content, status=status.HTTP_403_FORBIDDEN)
 
     def delete(self, request, *args, **kwargs):
@@ -312,7 +312,7 @@ class ZoneNameServerDetail(MregRetrieveUpdateDestroyAPIView):
 
     def patch(self, request: Request, *args, **kwargs):
         if 'primary_ns' not in request.data:
-            return Response({'ERROR': 'No nameserver found in body'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response({'error': 'No nameserver found in body'}, status=status.HTTP_400_BAD_REQUEST)
         zone = self.get_object()
         nameservers = _get_request_nameservers(request)
         _validate_nameservers(nameservers)

--- a/mreg/api/views.py
+++ b/mreg/api/views.py
@@ -91,7 +91,7 @@ LDAP_CALL_FAILURES = Counter(
 PROMETHEUS_METRICS_TEXT_SCHEMA = {
     "type": "string",
     "description": "Prometheus exposition text format.",
-    "examples": ["# HELP mreg_http_requests_total Total HTTP requests.\n# TYPE mreg_http_requests_total counter\n"],
+    "example": "# HELP mreg_http_requests_total Total HTTP requests.\n# TYPE mreg_http_requests_total counter\n",
 }
 
 

--- a/mreg/api/views.py
+++ b/mreg/api/views.py
@@ -29,6 +29,7 @@ from mreg.api.serializers import (
     HealthHeartbeatSerializer,
     MetaVersionsSerializer,
     MregVersionSerializer,
+    REPORTED_LIBRARY_VERSION_FIELDS,
     UserInfoSerializer,
 )
 from mreg.models.auth import User
@@ -86,24 +87,6 @@ LDAP_CALL_FAILURES = Counter(
     "LDAP call failures by operation and exception type",
     ["operation", "exception"],
 )
-
-# Note the order here. This order is preserved in the response.
-# Also, we add libpq-data to the end of this list so letting psycopg
-# be last makes the context of the libpq version more clear.
-LIBRARIES_TO_REPORT = [
-    "djangorestframework",
-    "django-auth-ldap",
-    "django-filter", 
-    "django-logging-json",
-    "django-netfields",
-    "drf-standardized-errors",
-    "gunicorn", 
-    "sentry-sdk",
-    "structlog",
-    "rich",
-    "psycopg",
-]
-
 
 PROMETHEUS_METRICS_TEXT_SCHEMA = {
     "type": "string",
@@ -270,7 +253,7 @@ class MetaVersions(APIView):
             "django": django.get_version(),
         }
 
-        for library in LIBRARIES_TO_REPORT:
+        for library in REPORTED_LIBRARY_VERSION_FIELDS:
             try:
                 data[library] = version(library)
             except Exception as e:

--- a/mreg/api/views.py
+++ b/mreg/api/views.py
@@ -20,7 +20,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from django.http import HttpResponse
-from drf_spectacular.utils import OpenApiTypes, extend_schema
+from drf_spectacular.utils import extend_schema
 from prometheus_client import CONTENT_TYPE_LATEST, Counter, Histogram, generate_latest
 
 from mreg.__about__ import __version__ as mreg_version
@@ -103,6 +103,13 @@ LIBRARIES_TO_REPORT = [
     "rich",
     "psycopg",
 ]
+
+
+PROMETHEUS_METRICS_TEXT_SCHEMA = {
+    "type": "string",
+    "description": "Prometheus exposition text format.",
+    "examples": ["# HELP mreg_http_requests_total Total HTTP requests.\n# TYPE mreg_http_requests_total counter\n"],
+}
 
 
 class ObtainExpiringAuthToken(ObtainAuthToken):
@@ -340,6 +347,6 @@ class MetricsView(APIView):
 
     permission_classes = ()
 
-    @extend_schema(responses={status.HTTP_200_OK: OpenApiTypes.STR})
+    @extend_schema(responses={(status.HTTP_200_OK, "text/plain"): PROMETHEUS_METRICS_TEXT_SCHEMA})
     def get(self, request: Request):
         return HttpResponse(generate_latest(), content_type=CONTENT_TYPE_LATEST)

--- a/mreg/api/views.py
+++ b/mreg/api/views.py
@@ -20,10 +20,17 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from django.http import HttpResponse
+from drf_spectacular.utils import OpenApiTypes, extend_schema
 from prometheus_client import CONTENT_TYPE_LATEST, Counter, Histogram, generate_latest
 
 from mreg.__about__ import __version__ as mreg_version
 from mreg.api.permissions import IsSuperOrNetworkAdminMember
+from mreg.api.serializers import (
+    HealthHeartbeatSerializer,
+    MetaVersionsSerializer,
+    MregVersionSerializer,
+    UserInfoSerializer,
+)
 from mreg.models.auth import User
 from mreg.models.base import ExpiringToken
 from mreg.models.network import NetGroupRegexPermission
@@ -142,6 +149,7 @@ class TokenLogout(APIView):
 
     permission_classes = (IsAuthenticated,)
 
+    @extend_schema(request=None, responses={status.HTTP_200_OK: None})
     def post(self, request: Request):
         # delete the user on logout to clean up the local user database and
         # group memberships. As the user owns the token, it will also be deleted.
@@ -152,6 +160,7 @@ class TokenIsValid(APIView):
 
     permission_classes = (IsAuthenticated,)
 
+    @extend_schema(responses={status.HTTP_200_OK: None})
     def get(self, request: Request):
         return Response(status=status.HTTP_200_OK)  
 
@@ -163,6 +172,7 @@ class UserInfo(APIView):
 
     permission_classes = (IsAuthenticated,)
 
+    @extend_schema(responses={status.HTTP_200_OK: UserInfoSerializer})
     def get(self, request: Request):
         # Identify the requesting user
         req_user = User.from_request(request)
@@ -235,6 +245,7 @@ class MregVersion(APIView):
     
     permission_classes = (IsAuthenticated,)
 
+    @extend_schema(responses={status.HTTP_200_OK: MregVersionSerializer})
     def get(self, request: Request):
         data = {
             "version": mreg_version,
@@ -245,6 +256,7 @@ class MetaVersions(APIView):
 
     permission_classes = (IsSuperOrNetworkAdminMember,)
 
+    @extend_schema(responses={status.HTTP_200_OK: MetaVersionsSerializer})
     def get(self, request: Request):
         data = {
             "python": platform.python_version(),
@@ -263,6 +275,7 @@ class MetaVersions(APIView):
 
 
 class HealthHeartbeat(APIView):
+    @extend_schema(responses={status.HTTP_200_OK: HealthHeartbeatSerializer})
     def get(self, request: Request):
         uptime = int(time.time() - start_time)
         data = {
@@ -273,6 +286,12 @@ class HealthHeartbeat(APIView):
 
 
 class HealthLDAP(APIView):
+    @extend_schema(
+        responses={
+            status.HTTP_200_OK: None,
+            status.HTTP_503_SERVICE_UNAVAILABLE: None,
+        }
+    )
     def get(self, request: Request) -> Response:
         ok = self.check_ldap_connection()
         st = status.HTTP_200_OK if ok else status.HTTP_503_SERVICE_UNAVAILABLE
@@ -321,5 +340,6 @@ class MetricsView(APIView):
 
     permission_classes = ()
 
+    @extend_schema(responses={status.HTTP_200_OK: OpenApiTypes.STR})
     def get(self, request: Request):
         return HttpResponse(generate_latest(), content_type=CONTENT_TYPE_LATEST)

--- a/mreg/api/views.py
+++ b/mreg/api/views.py
@@ -20,7 +20,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from django.http import HttpResponse
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import OpenApiParameter, OpenApiTypes, extend_schema
 from prometheus_client import CONTENT_TYPE_LATEST, Counter, Histogram, generate_latest
 
 from mreg.__about__ import __version__ as mreg_version
@@ -97,6 +97,7 @@ PROMETHEUS_METRICS_TEXT_SCHEMA = {
 
 class ObtainExpiringAuthToken(ObtainAuthToken):
 
+    @extend_schema(auth=[])
     def post(self, request: Request, *args: Any, **kwargs: Any):
         serializer = self.serializer_class(data=request.data, context={"request": request})
         try:
@@ -162,7 +163,18 @@ class UserInfo(APIView):
 
     permission_classes = (IsAuthenticated,)
 
-    @extend_schema(responses={status.HTTP_200_OK: UserInfoSerializer})
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                "username",
+                OpenApiTypes.STR,
+                OpenApiParameter.QUERY,
+                required=False,
+                description="Username to inspect. Requires administrative privileges when querying another user.",
+            )
+        ],
+        responses={status.HTTP_200_OK: UserInfoSerializer},
+    )
     def get(self, request: Request):
         # Identify the requesting user
         req_user = User.from_request(request)
@@ -330,6 +342,9 @@ class MetricsView(APIView):
 
     permission_classes = ()
 
-    @extend_schema(responses={(status.HTTP_200_OK, "text/plain"): PROMETHEUS_METRICS_TEXT_SCHEMA})
+    @extend_schema(
+        auth=[],
+        responses={(status.HTTP_200_OK, "text/plain"): PROMETHEUS_METRICS_TEXT_SCHEMA},
+    )
     def get(self, request: Request):
         return HttpResponse(generate_latest(), content_type=CONTENT_TYPE_LATEST)

--- a/mregsite/settings.py
+++ b/mregsite/settings.py
@@ -19,6 +19,7 @@ from typing import Literal, TypeVar
 import structlog
 
 import mreg.log_processors
+import mreg.__about__
 
 
 DefaultT = TypeVar("DefaultT", str, int, float, bool)
@@ -205,6 +206,8 @@ INSTALLED_APPS = [
     'mreg',
     'hostpolicy',
     'drf_standardized_errors',
+    'drf_spectacular',
+    'drf_spectacular_sidecar',  # required for Django collectstatic discovery
 ]
 
 MIDDLEWARE = [
@@ -299,7 +302,7 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': (
         'mreg.api.permissions.IsAuthenticatedAndReadOnly',
     ),
-    'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.openapi.AutoSchema',
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
     
     # Other settings
     "EXCEPTION_HANDLER": "drf_standardized_errors.handler.exception_handler"
@@ -309,6 +312,18 @@ REST_FRAMEWORK_EXTENSIONS = {
     "DEFAULT_OBJECT_ETAG_FUNC": "rest_framework_extensions.utils.default_object_etag_func",
     "DEFAULT_LIST_ETAG_FUNC": "rest_framework_extensions.utils.default_list_etag_func",
 }
+
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'MREG API',
+    'DESCRIPTION': 'MREG API documentation',
+    'VERSION': mreg.__about__.__version__,
+    'SERVE_INCLUDE_SCHEMA': False,
+    # Sidecar (static swagger/redoc files) settings
+    'SWAGGER_UI_DIST': 'SIDECAR',  # shorthand to use the sidecar instead
+    'SWAGGER_UI_FAVICON_HREF': 'SIDECAR',
+    'REDOC_DIST': 'SIDECAR',
+}
+
 
 # TXT record(s) automatically added to a host when added to a ForwardZone.
 TXT_AUTO_RECORDS = {

--- a/mregsite/urls.py
+++ b/mregsite/urls.py
@@ -5,20 +5,18 @@ from django.conf import settings
 from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 
 
-swagger_view = SpectacularSwaggerView.as_view(url_name='schema')
 
 urlpatterns = [
     path('api/', include('mreg.api.urls')),
     path('api/v1/', include('hostpolicy.api.v1.urls')),
     path('api/v1/', include('mreg.api.v1.urls')),
     path('admin/', admin.site.urls),
-    # Download the schema as a file
-    path('schema/', SpectacularAPIView.as_view(), name='schema'),
     # Schema UIs
-    path('schema/swagger/', swagger_view, name='swagger'),
-    path('schema/redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
-    # Legacy alias for /docs/
-    path('docs/', swagger_view, name='docs'),
+    path('docs/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger'),
+    path('docs/redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
+    # Download the schema as a file
+    path('docs/schema/', SpectacularAPIView.as_view(), name='schema'),
+
 ]
 
 if settings.MREG_PROFILING_ENABLED:

--- a/mregsite/urls.py
+++ b/mregsite/urls.py
@@ -2,17 +2,23 @@ from django.contrib import admin
 from django.urls import include, path
 from django.conf import settings
 
-from rest_framework.schemas import get_schema_view
+from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 
-# Schema view for swagger api documentation
-schema_view = get_schema_view(title='mreg API')
+
+swagger_view = SpectacularSwaggerView.as_view(url_name='schema')
 
 urlpatterns = [
     path('api/', include('mreg.api.urls')),
     path('api/v1/', include('hostpolicy.api.v1.urls')),
     path('api/v1/', include('mreg.api.v1.urls')),
     path('admin/', admin.site.urls),
-    path('docs/', schema_view),
+    # Download the schema as a file
+    path('schema/', SpectacularAPIView.as_view(), name='schema'),
+    # Schema UIs
+    path('schema/swagger/', swagger_view, name='swagger'),
+    path('schema/redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
+    # Legacy alias for /docs/
+    path('docs/', swagger_view, name='docs'),
 ]
 
 if settings.MREG_PROFILING_ENABLED:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,9 @@ dependencies = [
     "sentry-sdk>=2.48.0",
     "tzdata>=2025.3",
     "drf-standardized-errors>=0.15",
-    # For OpenAPI schema generation.
-    "uritemplate",
-    "pyyaml",
+    # For OpenAPI schema generation
+    # Pinned to prevent breaking changes: https://drf-spectacular.readthedocs.io/en/latest/readme.html#release-management
+    "drf-spectacular[sidecar]==0.29.0",
     # For testing inside Docker image
     "unittest-parametrize",
     "prometheus-client>=0.20",

--- a/uv.lock
+++ b/uv.lock
@@ -3,10 +3,13 @@ revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12' and extra != 'group-4-mreg-django52' and extra == 'group-4-mreg-django60'",
-    "python_full_version < '3.12' and extra != 'group-4-mreg-django52' and extra == 'group-4-mreg-django60'",
-    "extra == 'group-4-mreg-django52' and extra != 'group-4-mreg-django60'",
+    "python_full_version == '3.11.*' and extra != 'group-4-mreg-django52' and extra == 'group-4-mreg-django60'",
+    "python_full_version < '3.11' and extra != 'group-4-mreg-django52' and extra == 'group-4-mreg-django60'",
+    "python_full_version >= '3.11' and extra == 'group-4-mreg-django52' and extra != 'group-4-mreg-django60'",
+    "python_full_version < '3.11' and extra == 'group-4-mreg-django52' and extra != 'group-4-mreg-django60'",
     "python_full_version >= '3.12' and extra != 'group-4-mreg-django52' and extra != 'group-4-mreg-django60'",
-    "python_full_version < '3.12' and extra != 'group-4-mreg-django52' and extra != 'group-4-mreg-django60'",
+    "python_full_version == '3.11.*' and extra != 'group-4-mreg-django52' and extra != 'group-4-mreg-django60'",
+    "python_full_version < '3.11' and extra != 'group-4-mreg-django52' and extra != 'group-4-mreg-django60'",
 ]
 conflicts = [[
     { package = "mreg", group = "django52" },
@@ -46,6 +49,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/63/40/f03da1264ae8f7cfdbf9146542e5e7e8100a4c66ab48e791df9a03d3f6c0/asgiref-3.11.1.tar.gz", hash = "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce", size = 38550, upload-time = "2026-02-03T13:30:14.33Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/0a/a72d10ed65068e115044937873362e6e32fab1b7dce0046aeb224682c989/asgiref-3.11.1-py3-none-any.whl", hash = "sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133", size = 24345, upload-time = "2026-02-03T13:30:13.039Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
 ]
 
 [[package]]
@@ -324,9 +336,12 @@ name = "django"
 version = "5.2.15"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.12' and extra != 'group-4-mreg-django52' and extra == 'group-4-mreg-django60'",
-    "extra == 'group-4-mreg-django52' and extra != 'group-4-mreg-django60'",
-    "python_full_version < '3.12' and extra != 'group-4-mreg-django52' and extra != 'group-4-mreg-django60'",
+    "python_full_version == '3.11.*' and extra != 'group-4-mreg-django52' and extra == 'group-4-mreg-django60'",
+    "python_full_version < '3.11' and extra != 'group-4-mreg-django52' and extra == 'group-4-mreg-django60'",
+    "python_full_version >= '3.11' and extra == 'group-4-mreg-django52' and extra != 'group-4-mreg-django60'",
+    "python_full_version < '3.11' and extra == 'group-4-mreg-django52' and extra != 'group-4-mreg-django60'",
+    "python_full_version == '3.11.*' and extra != 'group-4-mreg-django52' and extra != 'group-4-mreg-django60'",
+    "python_full_version < '3.11' and extra != 'group-4-mreg-django52' and extra != 'group-4-mreg-django60'",
 ]
 dependencies = [
     { name = "asgiref", marker = "python_full_version < '3.12' or extra == 'group-4-mreg-django52'" },
@@ -446,6 +461,42 @@ wheels = [
 ]
 
 [[package]]
+name = "drf-spectacular"
+version = "0.29.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django", version = "5.2.15", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or extra == 'group-4-mreg-django52'" },
+    { name = "django", version = "6.0.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra != 'group-4-mreg-django52') or (extra == 'group-4-mreg-django52' and extra == 'group-4-mreg-django60')" },
+    { name = "djangorestframework" },
+    { name = "inflection" },
+    { name = "jsonschema" },
+    { name = "pyyaml" },
+    { name = "uritemplate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/0e/a4f50d83e76cbe797eda88fc0083c8ca970cfa362b5586359ef06ec6f70a/drf_spectacular-0.29.0.tar.gz", hash = "sha256:0a069339ea390ce7f14a75e8b5af4a0860a46e833fd4af027411a3e94fc1a0cc", size = 241722, upload-time = "2025-11-02T03:40:26.348Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d9/502c56fc3ca960075d00956283f1c44e8cafe433dada03f9ed2821f3073b/drf_spectacular-0.29.0-py3-none-any.whl", hash = "sha256:d1ee7c9535d89848affb4427347f7c4a22c5d22530b8842ef133d7b72e19b41a", size = 105433, upload-time = "2025-11-02T03:40:24.823Z" },
+]
+
+[package.optional-dependencies]
+sidecar = [
+    { name = "drf-spectacular-sidecar" },
+]
+
+[[package]]
+name = "drf-spectacular-sidecar"
+version = "2026.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django", version = "5.2.15", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or extra == 'group-4-mreg-django52'" },
+    { name = "django", version = "6.0.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra != 'group-4-mreg-django52') or (extra == 'group-4-mreg-django52' and extra == 'group-4-mreg-django60')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/51/9e038d14bf51a0bd051e8bcb690287349c908fa7ba69021d9f3e5d5ac51f/drf_spectacular_sidecar-2026.7.1.tar.gz", hash = "sha256:40113c4066c7bc3ef15a7ce1c40cda227a907a9986748024a813a9e0595eba25", size = 2593211, upload-time = "2026-07-01T13:39:06.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/d08f5c79f7643dbff4512605c28b75481966ed6c8cc9b397c9dd2ee91cd1/drf_spectacular_sidecar-2026.7.1-py3-none-any.whl", hash = "sha256:bc6d50c9b64660e45e09296d39553b3e759eedd825fc41d631ee5b3f88e0c5de", size = 2617384, upload-time = "2026-07-01T13:39:03.787Z" },
+]
+
+[[package]]
 name = "drf-standardized-errors"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -541,12 +592,49 @@ wheels = [
 ]
 
 [[package]]
+name = "inflection"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/7e/691d061b7329bc8d54edbf0ec22fbfb2afe61facb681f9aaa9bff7a27d04/inflection-0.5.1.tar.gz", hash = "sha256:1a29730d366e996aaacffb2f1f1cb9593dc38e2ddd30c91250c6dde09ea9b417", size = 15091, upload-time = "2020-08-22T08:16:29.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/91/aa6bde563e0085a02a435aa99b49ef75b0a4b062635e606dab23ce18d720/inflection-0.5.1-py2.py3-none-any.whl", hash = "sha256:f38b2b640938a4f35ade69ac3d053042959b62a0f1076a5bbaa1b9526605a8a2", size = 9454, upload-time = "2020-08-22T08:16:27.816Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'group-4-mreg-django52' and extra == 'group-4-mreg-django60')" },
+    { name = "rpds-py", version = "2026.6.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'group-4-mreg-django52' and extra == 'group-4-mreg-django60')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -581,19 +669,18 @@ dependencies = [
     { name = "django-logging-json" },
     { name = "django-netfields" },
     { name = "djangorestframework" },
+    { name = "drf-spectacular", extra = ["sidecar"] },
     { name = "drf-standardized-errors" },
     { name = "gunicorn" },
     { name = "idna" },
     { name = "pika" },
     { name = "prometheus-client" },
     { name = "psycopg", extra = ["binary", "pool"] },
-    { name = "pyyaml" },
     { name = "rich" },
     { name = "sentry-sdk" },
     { name = "structlog" },
     { name = "tzdata" },
     { name = "unittest-parametrize" },
-    { name = "uritemplate" },
 ]
 
 [package.dev-dependencies]
@@ -633,19 +720,18 @@ requires-dist = [
     { name = "django-logging-json", specifier = ">=1.15" },
     { name = "django-netfields", specifier = ">=1.3.2" },
     { name = "djangorestframework", specifier = ">=3.16.0,<3.17" },
+    { name = "drf-spectacular", extras = ["sidecar"], specifier = "==0.29.0" },
     { name = "drf-standardized-errors", specifier = ">=0.15" },
     { name = "gunicorn", specifier = ">=23.0.0" },
     { name = "idna", specifier = ">=3.11" },
     { name = "pika", specifier = ">=1.3.2" },
     { name = "prometheus-client", specifier = ">=0.20" },
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.3" },
-    { name = "pyyaml" },
     { name = "rich", specifier = ">=14" },
     { name = "sentry-sdk", specifier = ">=2.48.0" },
     { name = "structlog", specifier = ">=25" },
     { name = "tzdata", specifier = ">=2025.3" },
     { name = "unittest-parametrize" },
-    { name = "uritemplate" },
 ]
 
 [package.metadata.requires-dev]
@@ -1002,6 +1088,21 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'group-4-mreg-django52' and extra == 'group-4-mreg-django60')" },
+    { name = "rpds-py", version = "2026.6.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'group-4-mreg-django52' and extra == 'group-4-mreg-django60')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'group-4-mreg-django52' and extra == 'group-4-mreg-django60')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1027,6 +1128,261 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/0c/0c411a0ec64ccb6d104dcabe0e713e05e153a9a2c3c2bd2b32ce412166fe/rpds_py-0.30.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:679ae98e00c0e8d68a7fda324e16b90fd5260945b45d3b824c892cec9eea3288", size = 370490, upload-time = "2025-11-30T20:21:33.256Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6a/4ba3d0fb7297ebae71171822554abe48d7cab29c28b8f9f2c04b79988c05/rpds_py-0.30.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4cc2206b76b4f576934f0ed374b10d7ca5f457858b157ca52064bdfc26b9fc00", size = 359751, upload-time = "2025-11-30T20:21:34.591Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/7c/e4933565ef7f7a0818985d87c15d9d273f1a649afa6a52ea35ad011195ea/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:389a2d49eded1896c3d48b0136ead37c48e221b391c052fba3f4055c367f60a6", size = 389696, upload-time = "2025-11-30T20:21:36.122Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/01/6271a2511ad0815f00f7ed4390cf2567bec1d4b1da39e2c27a41e6e3b4de/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:32c8528634e1bf7121f3de08fa85b138f4e0dc47657866630611b03967f041d7", size = 403136, upload-time = "2025-11-30T20:21:37.728Z" },
+    { url = "https://files.pythonhosted.org/packages/55/64/c857eb7cd7541e9b4eee9d49c196e833128a55b89a9850a9c9ac33ccf897/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f207f69853edd6f6700b86efb84999651baf3789e78a466431df1331608e5324", size = 524699, upload-time = "2025-11-30T20:21:38.92Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/ed/94816543404078af9ab26159c44f9e98e20fe47e2126d5d32c9d9948d10a/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:67b02ec25ba7a9e8fa74c63b6ca44cf5707f2fbfadae3ee8e7494297d56aa9df", size = 412022, upload-time = "2025-11-30T20:21:40.407Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b5/707f6cf0066a6412aacc11d17920ea2e19e5b2f04081c64526eb35b5c6e7/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c0e95f6819a19965ff420f65578bacb0b00f251fefe2c8b23347c37174271f3", size = 390522, upload-time = "2025-11-30T20:21:42.17Z" },
+    { url = "https://files.pythonhosted.org/packages/13/4e/57a85fda37a229ff4226f8cbcf09f2a455d1ed20e802ce5b2b4a7f5ed053/rpds_py-0.30.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:a452763cc5198f2f98898eb98f7569649fe5da666c2dc6b5ddb10fde5a574221", size = 404579, upload-time = "2025-11-30T20:21:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/da/c9339293513ec680a721e0e16bf2bac3db6e5d7e922488de471308349bba/rpds_py-0.30.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e0b65193a413ccc930671c55153a03ee57cecb49e6227204b04fae512eb657a7", size = 421305, upload-time = "2025-11-30T20:21:44.994Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/be/522cb84751114f4ad9d822ff5a1aa3c98006341895d5f084779b99596e5c/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:858738e9c32147f78b3ac24dc0edb6610000e56dc0f700fd5f651d0a0f0eb9ff", size = 572503, upload-time = "2025-11-30T20:21:46.91Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/9b/de879f7e7ceddc973ea6e4629e9b380213a6938a249e94b0cdbcc325bb66/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:da279aa314f00acbb803da1e76fa18666778e8a8f83484fba94526da5de2cba7", size = 598322, upload-time = "2025-11-30T20:21:48.709Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ac/f01fc22efec3f37d8a914fc1b2fb9bcafd56a299edbe96406f3053edea5a/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7c64d38fb49b6cdeda16ab49e35fe0da2e1e9b34bc38bd78386530f218b37139", size = 560792, upload-time = "2025-11-30T20:21:50.024Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/da/4e2b19d0f131f35b6146425f846563d0ce036763e38913d917187307a671/rpds_py-0.30.0-cp310-cp310-win32.whl", hash = "sha256:6de2a32a1665b93233cde140ff8b3467bdb9e2af2b91079f0333a0974d12d464", size = 221901, upload-time = "2025-11-30T20:21:51.32Z" },
+    { url = "https://files.pythonhosted.org/packages/96/cb/156d7a5cf4f78a7cc571465d8aec7a3c447c94f6749c5123f08438bcf7bc/rpds_py-0.30.0-cp310-cp310-win_amd64.whl", hash = "sha256:1726859cd0de969f88dc8673bdd954185b9104e05806be64bcd87badbe313169", size = 235823, upload-time = "2025-11-30T20:21:52.505Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/6e/f964e88b3d2abee2a82c1ac8366da848fce1c6d834dc2132c3fda3970290/rpds_py-0.30.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425", size = 370157, upload-time = "2025-11-30T20:21:53.789Z" },
+    { url = "https://files.pythonhosted.org/packages/94/ba/24e5ebb7c1c82e74c4e4f33b2112a5573ddc703915b13a073737b59b86e0/rpds_py-0.30.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d", size = 359676, upload-time = "2025-11-30T20:21:55.475Z" },
+    { url = "https://files.pythonhosted.org/packages/84/86/04dbba1b087227747d64d80c3b74df946b986c57af0a9f0c98726d4d7a3b/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4", size = 389938, upload-time = "2025-11-30T20:21:57.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/bb/1463f0b1722b7f45431bdd468301991d1328b16cffe0b1c2918eba2c4eee/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f", size = 402932, upload-time = "2025-11-30T20:21:58.47Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ee/2520700a5c1f2d76631f948b0736cdf9b0acb25abd0ca8e889b5c62ac2e3/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4", size = 525830, upload-time = "2025-11-30T20:21:59.699Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ad/bd0331f740f5705cc555a5e17fdf334671262160270962e69a2bdef3bf76/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97", size = 412033, upload-time = "2025-11-30T20:22:00.991Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/1e/372195d326549bb51f0ba0f2ecb9874579906b97e08880e7a65c3bef1a99/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89", size = 390828, upload-time = "2025-11-30T20:22:02.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2b/d88bb33294e3e0c76bc8f351a3721212713629ffca1700fa94979cb3eae8/rpds_py-0.30.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d", size = 404683, upload-time = "2025-11-30T20:22:04.367Z" },
+    { url = "https://files.pythonhosted.org/packages/50/32/c759a8d42bcb5289c1fac697cd92f6fe01a018dd937e62ae77e0e7f15702/rpds_py-0.30.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038", size = 421583, upload-time = "2025-11-30T20:22:05.814Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/81/e729761dbd55ddf5d84ec4ff1f47857f4374b0f19bdabfcf929164da3e24/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7", size = 572496, upload-time = "2025-11-30T20:22:07.713Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f6/69066a924c3557c9c30baa6ec3a0aa07526305684c6f86c696b08860726c/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed", size = 598669, upload-time = "2025-11-30T20:22:09.312Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/48/905896b1eb8a05630d20333d1d8ffd162394127b74ce0b0784ae04498d32/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85", size = 561011, upload-time = "2025-11-30T20:22:11.309Z" },
+    { url = "https://files.pythonhosted.org/packages/22/16/cd3027c7e279d22e5eb431dd3c0fbc677bed58797fe7581e148f3f68818b/rpds_py-0.30.0-cp311-cp311-win32.whl", hash = "sha256:55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c", size = 221406, upload-time = "2025-11-30T20:22:13.101Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/5b/e7b7aa136f28462b344e652ee010d4de26ee9fd16f1bfd5811f5153ccf89/rpds_py-0.30.0-cp311-cp311-win_amd64.whl", hash = "sha256:a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825", size = 236024, upload-time = "2025-11-30T20:22:14.853Z" },
+    { url = "https://files.pythonhosted.org/packages/14/a6/364bba985e4c13658edb156640608f2c9e1d3ea3c81b27aa9d889fff0e31/rpds_py-0.30.0-cp311-cp311-win_arm64.whl", hash = "sha256:47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229", size = 229069, upload-time = "2025-11-30T20:22:16.577Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/98a2f4ac921d82f33e03f3835f5bf3a4a40aa1bfdc57975e74a97b2b4bdd/rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad", size = 375086, upload-time = "2025-11-30T20:22:17.93Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05", size = 359053, upload-time = "2025-11-30T20:22:19.297Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/ae157e83a6357eceff62ba7e52113e3ec4834a84cfe07fa4b0757a7d105f/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28", size = 390763, upload-time = "2025-11-30T20:22:21.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/36/eb2eb8515e2ad24c0bd43c3ee9cd74c33f7ca6430755ccdb240fd3144c44/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd", size = 408951, upload-time = "2025-11-30T20:22:23.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/65/ad8dc1784a331fabbd740ef6f71ce2198c7ed0890dab595adb9ea2d775a1/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f", size = 514622, upload-time = "2025-11-30T20:22:25.16Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/0cfa7ae158e15e143fe03993b5bcd743a59f541f5952e1546b1ac1b5fd45/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1", size = 414492, upload-time = "2025-11-30T20:22:26.505Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23", size = 394080, upload-time = "2025-11-30T20:22:27.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d5/a266341051a7a3ca2f4b750a3aa4abc986378431fc2da508c5034d081b70/rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6", size = 408680, upload-time = "2025-11-30T20:22:29.341Z" },
+    { url = "https://files.pythonhosted.org/packages/10/3b/71b725851df9ab7a7a4e33cf36d241933da66040d195a84781f49c50490c/rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51", size = 423589, upload-time = "2025-11-30T20:22:31.469Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2b/e59e58c544dc9bd8bd8384ecdb8ea91f6727f0e37a7131baeff8d6f51661/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5", size = 573289, upload-time = "2025-11-30T20:22:32.997Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3e/a18e6f5b460893172a7d6a680e86d3b6bc87a54c1f0b03446a3c8c7b588f/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e", size = 599737, upload-time = "2025-11-30T20:22:34.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e2/714694e4b87b85a18e2c243614974413c60aa107fd815b8cbc42b873d1d7/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394", size = 563120, upload-time = "2025-11-30T20:22:35.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ab/d5d5e3bcedb0a77f4f613706b750e50a5a3ba1c15ccd3665ecc636c968fd/rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf", size = 223782, upload-time = "2025-11-30T20:22:37.271Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b", size = 240463, upload-time = "2025-11-30T20:22:39.021Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d2/b91dc748126c1559042cfe41990deb92c4ee3e2b415f6b5234969ffaf0cc/rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e", size = 230868, upload-time = "2025-11-30T20:22:40.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
+    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+    { url = "https://files.pythonhosted.org/packages/69/71/3f34339ee70521864411f8b6992e7ab13ac30d8e4e3309e07c7361767d91/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58", size = 372292, upload-time = "2025-11-30T20:24:16.537Z" },
+    { url = "https://files.pythonhosted.org/packages/57/09/f183df9b8f2d66720d2ef71075c59f7e1b336bec7ee4c48f0a2b06857653/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a", size = 362128, upload-time = "2025-11-30T20:24:18.086Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/68/5c2594e937253457342e078f0cc1ded3dd7b2ad59afdbf2d354869110a02/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb", size = 391542, upload-time = "2025-11-30T20:24:20.092Z" },
+    { url = "https://files.pythonhosted.org/packages/49/5c/31ef1afd70b4b4fbdb2800249f34c57c64beb687495b10aec0365f53dfc4/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c", size = 404004, upload-time = "2025-11-30T20:24:22.231Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/63/0cfbea38d05756f3440ce6534d51a491d26176ac045e2707adc99bb6e60a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3", size = 527063, upload-time = "2025-11-30T20:24:24.302Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e6/01e1f72a2456678b0f618fc9a1a13f882061690893c192fcad9f2926553a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5", size = 413099, upload-time = "2025-11-30T20:24:25.916Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/25/8df56677f209003dcbb180765520c544525e3ef21ea72279c98b9aa7c7fb/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738", size = 392177, upload-time = "2025-11-30T20:24:27.834Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/b4/0a771378c5f16f8115f796d1f437950158679bcd2a7c68cf251cfb00ed5b/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f", size = 406015, upload-time = "2025-11-30T20:24:29.457Z" },
+    { url = "https://files.pythonhosted.org/packages/36/d8/456dbba0af75049dc6f63ff295a2f92766b9d521fa00de67a2bd6427d57a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877", size = 423736, upload-time = "2025-11-30T20:24:31.22Z" },
+    { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
+    { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.6.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and extra != 'group-4-mreg-django52' and extra == 'group-4-mreg-django60'",
+    "python_full_version == '3.11.*' and extra != 'group-4-mreg-django52' and extra == 'group-4-mreg-django60'",
+    "python_full_version >= '3.11' and extra == 'group-4-mreg-django52' and extra != 'group-4-mreg-django60'",
+    "python_full_version >= '3.12' and extra != 'group-4-mreg-django52' and extra != 'group-4-mreg-django60'",
+    "python_full_version == '3.11.*' and extra != 'group-4-mreg-django52' and extra != 'group-4-mreg-django60'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/1f/a2dca5ffdbf1d475ffc4e80e4d5d720ff3a00f691795910116960ee12511/rpds_py-2026.6.3-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:7b689145a1485c335569bd056464f3243a29af7ed3871c7be31ad624ba239bc7", size = 342174, upload-time = "2026-06-30T07:14:54.821Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/dc/323d08583c0832911768663d1944f0107fcd4088704858d84b5e06d105a0/rpds_py-2026.6.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:db08f45aecde626498fb3df07bcf6d2ec040af42e859a4f5040d79c200342911", size = 345513, upload-time = "2026-06-30T07:14:56.515Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2a/e31989834d18d2f26ec1d2774c5b1eb3331df4ea8ada525175294c94b48a/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:acc992ab27b15f852c76755eb2ab7dce86585ddadba6fa5946e58556088845b4", size = 373783, upload-time = "2026-06-30T07:14:57.736Z" },
+    { url = "https://files.pythonhosted.org/packages/87/fe/e80107ee3639585c9941c17d6a42cd65325022f656c023191fce78c324c8/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7f88d653e7b3b779d71ae7454e20dcc9b6bae903f33c269db9f2be41bda3f261", size = 378316, upload-time = "2026-06-30T07:14:59.077Z" },
+    { url = "https://files.pythonhosted.org/packages/22/6f/81e3adf81acfb6fa694de2a6e4e7d8863121e3e0799e0a7725e6cf5679c4/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e52655eaf81e32593abedaa4bfe33170c8cfedf3365ed9be6e11e07f148f0278", size = 499423, upload-time = "2026-06-30T07:15:00.488Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/9a/41263969df0ce3d9af2a96d5005a288200af1989aed3354bfceb5fc0b21f/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dfcc8b909769d19db55c7cc9541eb64b9b774b1057ffffb4f1048070475bb9f9", size = 386077, upload-time = "2026-06-30T07:15:01.911Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/19/7e98f468bd50346faff5b10e5297374b443bfdddacc8e9fbc65984539597/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c1255b302953c86a486b81d330d5ee1d5bd937691ce271b6be0ef0e299eaab7", size = 371315, upload-time = "2026-06-30T07:15:03.317Z" },
+    { url = "https://files.pythonhosted.org/packages/99/3c/2b973b4d371906a134b03decfea7f5d9835a2c6d263454392e15b64b5b18/rpds_py-2026.6.3-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:8d2294a31386bfa251d8c8a39472beee17db67d4f1a6eabea665d35c9a4461c3", size = 383502, upload-time = "2026-06-30T07:15:04.627Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2a/12e2799500af0a307bca76b63361c51f9fe479223561489c29eea1f2ee41/rpds_py-2026.6.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f8f23ead891a3b762f35ab3b04623da7056545b48aa60d59957e6789914545da", size = 402673, upload-time = "2026-06-30T07:15:05.856Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e3/21e5872d165fe08be4f229e3d5ee9d90019c0bf0e5538de60dbd54009450/rpds_py-2026.6.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:421aba32367055614287a4292b6a17f1939c9452299f7a0209c117e990b646d4", size = 549964, upload-time = "2026-06-30T07:15:07.159Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d0/5ee0fe36844297de8123bee27bc12078c1a7416ad9f1b8a8ca18d6b0c0ac/rpds_py-2026.6.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:1e5822dfc2f0d4ab7e745eaa6d85945069329beeccef965af3f3bb26058fcab6", size = 615446, upload-time = "2026-06-30T07:15:08.531Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/80/1ea5873cb683f2fbe5f21b23ea1f6d179ead19f3c5b249b7eb5dca568ef2/rpds_py-2026.6.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:83e35b57523816c8613fd0776b40cd8bb9f596b37ddd2692eb4a6bb5ab2f8c93", size = 576975, upload-time = "2026-06-30T07:15:09.97Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e1/90ef639217a5ddb15b7f4f61b1c33911fd044ad03c311bafdd2bcab85582/rpds_py-2026.6.3-cp311-cp311-win32.whl", hash = "sha256:de3eceba0b683bcbb1ab93da016d0270df1f9ae7be716b40214c5dafac6ea45a", size = 204453, upload-time = "2026-06-30T07:15:11.324Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/b7/b7a1695d7af36f521fb11e80d6d3adbd744f73b921859bd3c2a2c0dc706f/rpds_py-2026.6.3-cp311-cp311-win_amd64.whl", hash = "sha256:2c54a076ca4d370980ab57bc0e31df57bbe8d41340436a90ef8b1219a3cbb127", size = 223219, upload-time = "2026-06-30T07:15:12.476Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/a2/145afacf796e4506062825941176ad9445c2dcf2b3b6a1f13d3030a15e19/rpds_py-2026.6.3-cp311-cp311-win_arm64.whl", hash = "sha256:168c733a7112e071bb7a66460e667edfcff06c017a3c523f7a8a8e08d0140804", size = 219137, upload-time = "2026-06-30T07:15:13.631Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/be/2e8974163072e7bab7df1a5acd54c4498e75e35d6d18b864d3a9d5dadc92/rpds_py-2026.6.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a0811d33247c3d6128a3001d763f2aa056bb3425204335400ac54f89eec3a0d0", size = 343691, upload-time = "2026-06-30T07:15:14.96Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/73/319dfa745dd668efe89309141ded489126461fcecd2b8f3a3cda185129b6/rpds_py-2026.6.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:538949e262e46caa31ac01bdb3c1e8f642622922cacbabbae6a8445d9dc33eaf", size = 338542, upload-time = "2026-06-30T07:15:16.267Z" },
+    { url = "https://files.pythonhosted.org/packages/21/63/4239893be1c4d09b709b1a8f6be4188f0870084ff547f46606b8a75f1b03/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55927d532399c2c646100ff7feb48eaa940ad70f42cd68e1328f3ded9f81ca24", size = 368180, upload-time = "2026-06-30T07:15:17.62Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ca/9c5de382225234ceb37b1844ebdb140db12b2a278bb9efe2fcd19f6c82ce/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f56f1695bc5c0871cbc33dc0130fcf503aab0c57dcc5a6700a4f49eba4f2652e", size = 375067, upload-time = "2026-06-30T07:15:18.952Z" },
+    { url = "https://files.pythonhosted.org/packages/87/dc/863f69d1bf04ade34b7fe0d59b9fdf6f0135fe2d7cbca74f1d665589559d/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:270b293dae9058fc9fcedab50f13cebf46fb8ed1d1d54e0521a9da5d6b211975", size = 490509, upload-time = "2026-06-30T07:15:20.434Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ef/eac16a12048b45ec7c7fa94f2be3438a5f26bf9cc8580b18a1cfd609b7f6/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:127565fead0a10943b282957bd5447804ff3160ad79f2ad2635e6d249e380680", size = 382754, upload-time = "2026-06-30T07:15:21.831Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8f/d2f3f532616be4d06c316ef119683e832bd3d41e112bf3a88f4151c95b17/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecabd69db66de867690f9797f2f8fa27ba501bbc24540cbdbdc649cd15888ba6", size = 366189, upload-time = "2026-06-30T07:15:23.371Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/29/41a7b0e98a4b44cd676ab7598419623373eb43b20be68c084935c1a8cf88/rpds_py-2026.6.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:58eadac9cd119677b60e1cf8ac4052f35949d71b8a9e5556efccbe82533cf22a", size = 377750, upload-time = "2026-06-30T07:15:24.659Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/05/ecda0bec46f9a1565090bcdc941d023f6a25aff85fda28f89f8d19878152/rpds_py-2026.6.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7491ee23305ac3eb59e492b6945881f5cd77a6f731061a3f25b77fd40f9e99a4", size = 395576, upload-time = "2026-06-30T07:15:25.987Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a8/6ed52f03ee6cb854ce78785cc9a9a672eb880e83fd7224d471f667d151f1/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2c99f7e8ccb3dd6e3e4bfeac657a7b208c9bac8075f4b078c02d7404c34107fa", size = 543807, upload-time = "2026-06-30T07:15:27.356Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/d6/156c0d3eea27ba09b92562ba2364ba124c0a061b199e17eac637cd25a5e2/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:62698275682bf121181861295c9181e789030a2d516071f5b8f3c23c170cd0fc", size = 611187, upload-time = "2026-06-30T07:15:28.931Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/31/774212ed989c62f7f310220089f9b0a3fb8f40f5443d1727abd5d9f52bc9/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a214c993455f99a89aaeadc9b21241900037adc9d97203e374d75513c5911822", size = 573030, upload-time = "2026-06-30T07:15:30.553Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/50/22f73127a41f1ce4f87fe39aadfb9a126345801c274aa93ae88456249327/rpds_py-2026.6.3-cp312-cp312-win32.whl", hash = "sha256:501f9f04a588d6a09179368c57071301445191767c64e4b52a6aa9871f1ef5ed", size = 202185, upload-time = "2026-06-30T07:15:32.027Z" },
+    { url = "https://files.pythonhosted.org/packages/04/3a/f0ee4d4dde9d3b69dedf1b5f74e7a40017046d55052d173e418c6a94f960/rpds_py-2026.6.3-cp312-cp312-win_amd64.whl", hash = "sha256:2c958bf94822e9290a40aaf2a822d4bc5c88099093e3948ad6c571eca9272e5f", size = 220394, upload-time = "2026-06-30T07:15:33.359Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/83/3382fe37f809b59f02aac04dbc4e765b480b46ee0227ed516e3bdc4d3dfc/rpds_py-2026.6.3-cp312-cp312-win_arm64.whl", hash = "sha256:22bffe6042b9bcb0822bcd1955ec00e245daf17b4344e4ed8e9551b976b63e96", size = 215753, upload-time = "2026-06-30T07:15:34.778Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/9e/b818ee580026ec578138e961027a68820c40afeb1ec8f6819b54fb99e196/rpds_py-2026.6.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:3cfe765c1da0072636ca06628261e0ea05688e160d5c8a03e0217c3854037223", size = 343012, upload-time = "2026-06-30T07:15:36.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6b/686d9dc4359a8f163cfbbf89ee0b4e586431de22fe8248edb63a8cf50d49/rpds_py-2026.6.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f4d78253f6996be4901669ad25319f842f740eccf4d58e3c7f3dd39e6dde1d8f", size = 338203, upload-time = "2026-06-30T07:15:37.462Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/9b/069aa329940f8207615e091f5eedbbd40e1e15eac68a0790fd05ccdf796c/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54f45a148e28767bf343d33a684693c70e451c6f4c0e9904709a723fafbdfc1f", size = 367984, upload-time = "2026-06-30T07:15:39.008Z" },
+    { url = "https://files.pythonhosted.org/packages/14/db/34c203e4becff3703e4d3bc121842c00b8689197f398161203a880052f4e/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:842e7b070435622248c7a2c44ae53fa1440e073cc3023bc919fed570884097a7", size = 374815, upload-time = "2026-06-30T07:15:40.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7d/8071067d2cc453d916ad836e828c943f575e8a44612537759002a1e07381/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8020133a74bd81b4572dd8e4be028a6b1ebcd70e6726edc3918008c08bee6ee6", size = 490545, upload-time = "2026-06-30T07:15:41.729Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/42/da06c5aa8f0484ff07f270787434204d9f4535e2f8c3b51ed402267e63c3/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cdc7e35386f3847df728fbcb5e887e2d79c19e2fa1eba9e51b6621d23e3243af", size = 382828, upload-time = "2026-06-30T07:15:43.327Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d7/fe978efc2ae50abe48eb7464668ea99f53c010c60aeebb7b35ad27f23661/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acac386b453c2516111b50985d60ce46e7fadb5ea71ae7b25f4c946935bf27cf", size = 365678, upload-time = "2026-06-30T07:15:44.992Z" },
+    { url = "https://files.pythonhosted.org/packages/69/9d/1d8922e1990b2a6eb532b6ff53d3e73d2b3bbffc84116c75826bee73dfc6/rpds_py-2026.6.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:425560c6fa0415f27261727bb20bd097568485e5eb0c121f1949417d1c516885", size = 377811, upload-time = "2026-06-30T07:15:46.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/3d/198dceafb4fb034a6a47347e1b0735d34e0bd4a50be4e898d408ee66cb14/rpds_py-2026.6.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a550fb4950a06dde3beb4721f5ad4b25bf4513784665b0a8522c792e2bd822a4", size = 395382, upload-time = "2026-06-30T07:15:47.955Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f1/13968e49655d40b6b19d8b9140296bbc6f1d86b3f0f6c346cf9f1adddf4b/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f4bca01b63096f606e095734dd56e74e175f94cfbf24ff3d63281cec61f7bb7", size = 543832, upload-time = "2026-06-30T07:15:49.33Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ab/289bcb1b90bd3e40a2900c561fa0e2087345ecbb094f0b870f2345142b7c/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ccffae9a092a00deb7efd545fe5e2c33c33b88e7c054337e9a74c179347d0b7d", size = 611011, upload-time = "2026-06-30T07:15:50.847Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/16/5043105e679436ccfbc8e5e0dd2d663ed18a8b8113515fd06a5e5d77c83e/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1cf01971c4f2c5553b772a542e4aaf191789cd331bc2cd4ff0e6e65ba49e1e97", size = 572431, upload-time = "2026-06-30T07:15:52.394Z" },
+    { url = "https://files.pythonhosted.org/packages/85/ed/adab103321c0a6565d5ae1c2998349bc3ee175b82ccc5ae8fc04cc413075/rpds_py-2026.6.3-cp313-cp313-win32.whl", hash = "sha256:8c3d1e9c15b9d51ca0391e13da1a25a0a4df3c58a37c9dc368e0736cf7f69df0", size = 201710, upload-time = "2026-06-30T07:15:53.894Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ed/a03b09668e74e5dabbf2e211f6468e1820c0552f7b0500082da31841bf7b/rpds_py-2026.6.3-cp313-cp313-win_amd64.whl", hash = "sha256:9250a9a0a6fd4648b3f868da8d91a4c52b5811a62df58e753d50ae4454a36f80", size = 219454, upload-time = "2026-06-30T07:15:55.25Z" },
+    { url = "https://files.pythonhosted.org/packages/27/17/b8642c12930b71bc2b25831f6708ccf0f75abcd11883932ec9ce54ba3a78/rpds_py-2026.6.3-cp313-cp313-win_arm64.whl", hash = "sha256:900a67df3fd1660b035a4761c4ce73c382ea6b35f90f9863c36c6fd8bf8b09bb", size = 215063, upload-time = "2026-06-30T07:15:56.573Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/36/7fbe9dcdaf857fb3f63c2a2284b62492d95f5e8334e947e5fb6e7f68c9be/rpds_py-2026.6.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:931908d9fc855d8f74783377822be318edb6dcb19e47169dc038f9a1bf60b06e", size = 344510, upload-time = "2026-06-30T07:15:57.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/54/f785cc3d3f60839ca57a5af4927a9f347b07b2799c373fc20f7949f87c7e/rpds_py-2026.6.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7469697dce35be237db177d42e2a2ee26e6dcc5fc052078a6fefabd288c6edd", size = 339495, upload-time = "2026-06-30T07:15:59.238Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ef/d4cdaf309e6b095b43597103cf8c0b951d6cca2acce68c474f75ec12e0c7/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcfbcf66006befb9fd2aeaa9e01feaf881b4dc330a02ba07d2322b1c11be7b5d", size = 369454, upload-time = "2026-06-30T07:16:01.021Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4a/9559a68b7ee15db09d7981212e8c2e219d2a1d6d4faa0391d813c3496a36/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:847927daf4cffbd4e90e42bc890069897101edd015f956cb8721b3473372edda", size = 374583, upload-time = "2026-06-30T07:16:02.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/75/8964aa7d2c6e8ac43eba8eb6e6b0fdda1f46d39f2fc3e6aa9f2cb17f485d/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c1ef08a82bfe327cc156da694660f599923e2e6665b6d81c9c2d0ac9ffc8", size = 492919, upload-time = "2026-06-30T07:16:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/97/6908094ac804115e65aedfd90f1b5fee4eebebd3f6c4cfc5419939267565/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ae50181a047c871561212bb97f7932a2d45fb53e947bd9b57ebad85b529cbc53", size = 383725, upload-time = "2026-06-30T07:16:05.305Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/9c/0d1fdc2e7aba23e290d603bc494e97bd205bae262ce33c6b32a69768ed5e/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc319e5a1de4b6913aac94bf6a2f9e847371e0a140a43dd4991db1a09bc2d504", size = 367255, upload-time = "2026-06-30T07:16:07.086Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/fe/f0209ca4a9ed074bc8acb44dfd0e81c3122e94c9689f5645b7973a866719/rpds_py-2026.6.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e4316bf32babbed84e691e352faf967ce2f0f024174a8643c37c94a1080374fc", size = 379060, upload-time = "2026-06-30T07:16:08.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8d/f1cc54c616b9d8897de8738aac148d20afca93f68187475fe194d09a71b9/rpds_py-2026.6.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8c6e5a2f750cc71c3e3b11d71661f21d6f9bc6cebc6564b1466417a1ec03ec77", size = 395960, upload-time = "2026-06-30T07:16:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/04/aafff00f73aeca2945f734f1d483c64ab8f472d0864ab02377fd8e89c3b2/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4470ce197d4090875cf6affbf1f853338387428df97c4fb7b7106317b8214698", size = 545356, upload-time = "2026-06-30T07:16:11.816Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cc/e229663b9e4ddac5a4acbe9085dd80a71af2a5d356b8b39d6bff233f24b0/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea964164cc9afa72d4d9b23cc28dafae93693c0a53e0b42acbff15b22c3f9ddd", size = 612319, upload-time = "2026-06-30T07:16:13.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7a/8a0e6d3e6cd066af108b71b43122c3fe158dd9eb86acac626593a2582eb1/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:639c8929aa0afe81be836b04de888460d6bed38b9c54cfc18da8f6bfabf5af5d", size = 573508, upload-time = "2026-06-30T07:16:15.23Z" },
+    { url = "https://files.pythonhosted.org/packages/87/03/2a69ab618a789cf6cf85c86bb844c62d090e700ab1a2aa676b3741b6c516/rpds_py-2026.6.3-cp314-cp314-win32.whl", hash = "sha256:882076c00c0a608b131187055ddc5ae29f2e7eaf870d6168980420d58528a5c8", size = 202504, upload-time = "2026-06-30T07:16:16.893Z" },
+    { url = "https://files.pythonhosted.org/packages/85/62/a3892ba945f4e24c78f352e5de3c7620d8479f73f211406a97263d13c7d2/rpds_py-2026.6.3-cp314-cp314-win_amd64.whl", hash = "sha256:0be972be84cfcaf46c8c6edf690ca0f154ac17babf1f6a955a51579b34ad2dc5", size = 220380, upload-time = "2026-06-30T07:16:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e7/c2bd44dc831931815ad11ebb5f430b5a0a4d3caa9de837107876c30c3432/rpds_py-2026.6.3-cp314-cp314-win_arm64.whl", hash = "sha256:2a9c6f195058cb45335e8cc3802745c603d716eb96bc9625950c1aac71c0c703", size = 215976, upload-time = "2026-06-30T07:16:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9c/fff7b74bce9a091ec9a012a03f9ff5f69364eaf9451060dfc4486da2ffdd/rpds_py-2026.6.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:f90938e92afda60266da758ee7d363447f7f0138c9559f9e1811629580582d90", size = 346840, upload-time = "2026-06-30T07:16:21.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/44/77bcb1168b33704908295533d27f10eb811e9e3e193e8993dc99572211d3/rpds_py-2026.6.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec829541c45bca16e61c7ae50c20501f213605beb75d1aba91a6ee37fbbb56a4", size = 340282, upload-time = "2026-06-30T07:16:22.875Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3c/7a9081c7c9e645b39efe19e4ffbeccd80add246327cd9b888aecffd72317/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afd70d95892096cdb26f15a00c45907b17817577aa8d1c76b2dcc2788391f9e9", size = 370403, upload-time = "2026-06-30T07:16:24.415Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/69/af47021eb7dad6ff3396cb001c08f0f3c4d06c20253f75be6421a59fe6b7/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29dfa0533a5d4c94d4dfa1b694fcb56c9c63aad8330ffdd816fd225d0a7a162f", size = 376055, upload-time = "2026-06-30T07:16:26.111Z" },
+    { url = "https://files.pythonhosted.org/packages/81/fc/a3bcf517084396a6dd258c592567a3c011ba4557f2fde23dceaf26e74f2e/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:af05d726809bff6b141be124d4c7ce998f9c9c7f30edb1f46c07aa103d540b41", size = 494419, upload-time = "2026-06-30T07:16:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/eb/13d529d1788135425c7bf207f8463458ca5d92e43f3f701365b83e9dffc1/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9826217f048f620d9a712672818bf231442c1b35d96b227a07eabd11b4bb6945", size = 384848, upload-time = "2026-06-30T07:16:29.183Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f4/b7ac49f30013aba8f7b9566b1dd07e81de95e708c1374b7bacc5b9bc5c9c/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:536bceea4fa4acf7e1c61da2b5786304367c816c8895be71b8f537c480b0ea1f", size = 371369, upload-time = "2026-06-30T07:16:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/31/86/6260bafa622f788b07ddec0e52d810305c8b9b0b8c27f58a2ab04bf62b4f/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:bc0011654b91cc4fb2ae701bec0a0ba1e552c0714247fa7af6c59e0ccfa3a4e1", size = 379673, upload-time = "2026-06-30T07:16:32.486Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c3/03f1ee79a047b48daeca157c89a18509cde22b6b951d642b9b0af1be660a/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:539d75de9e0d536c84ff18dfeb805398e58227001ce09231a26a08b9aed1ee0e", size = 397500, upload-time = "2026-06-30T07:16:34.471Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/95/8ed0cd8c377dca12aea498f119fe639fc474d1461545c39d2b5872eb1c0f/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:166cf54d9f44fc6ceb53c7860258dde44a81406646de79f8ed3234fca3b6e538", size = 545978, upload-time = "2026-06-30T07:16:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/0eb57f0eaa83f8fc152a7e03de968ab77e1f00732bebc892b190c6eebde7/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d34c20167764fbcf927194d532dd7e0c56772f0a5f943fa5ef9e9afbba8fb9db", size = 613350, upload-time = "2026-06-30T07:16:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/de/e0674bdbc3ef7634989b3f854c3f34bc1f587d36e5bfdc5c378d57034619/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ea7bb13b7c9a29791f87a0387ba7d3ad3a6d783d827e4d3f27b40a0ff44495e2", size = 576486, upload-time = "2026-06-30T07:16:39.797Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f6/21101359743cd136ada781e8210a85769578422ba460672eea0e29739200/rpds_py-2026.6.3-cp314-cp314t-win32.whl", hash = "sha256:6de4744d05bd1aa1be4ed7ea1189e3979196808008113bbbf899a460966b925e", size = 201068, upload-time = "2026-06-30T07:16:41.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b2/9574d4d44f7760c2aa32d92a0a4f41698e33f5b204a0bf5c9758f52c79d5/rpds_py-2026.6.3-cp314-cp314t-win_amd64.whl", hash = "sha256:c7b9a2f8f4d8e90af72571d3d495deebdd7e3c75451f5b41719aee166e940fc2", size = 220600, upload-time = "2026-06-30T07:16:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ae/f23a2697e6ee6340a578b0f136be6483657bef0c6f9497b752bb5c0964bb/rpds_py-2026.6.3-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:e059c5dde6452b44424bd1834557556c226b57781dee1227af23518459722b13", size = 344726, upload-time = "2026-06-30T07:16:44.5Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/63/e7b3a1a5358dd32c930a1062d8e15b67fd6e8922e81df9e91706d66ee5c8/rpds_py-2026.6.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2f7c26fbc5acd2522b95d4177fe4710ffd8e9b20529e703ffbf8db4d93903f05", size = 339587, upload-time = "2026-06-30T07:16:46.255Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/64/10a85681916ca55fffb91b0a211f84e34297c109243484dd6394660a8a7c/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3086b538543802f84c843911242db20447de00d8752dd0efc936dbcf02218ba", size = 369585, upload-time = "2026-06-30T07:16:48.101Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c2/baf95c7c38823e12ba34407c5f5767a89e5cf2233895e56f608167ae9493/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f2e5c5ee828d42cb11760761c0af6507927bec42d0ad5458f97c9203b054617", size = 375479, upload-time = "2026-06-30T07:16:49.93Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/94/0aad06c72d65101e11d33528d438cda99a39ce0da99466e156158f2541d3/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed0c1e5d10cdc7135537988c74a0188da68e2f3c30813ba3744ab1e42e0480f9", size = 492418, upload-time = "2026-06-30T07:16:51.641Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/17/de3f5a479a1f056535d7489819639d8cd591ea6281d700390b43b1abd745/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c2642a7603ec0b16ed77da4555db3b4b472341904873788327c0b0d7b95f1bb", size = 384123, upload-time = "2026-06-30T07:16:53.622Z" },
+    { url = "https://files.pythonhosted.org/packages/46/7d/bf09bd1b145bb2671c03e1e6d1ab8651858d90d8c7dfeadd85a37a934fd8/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e4320744c1ffdd95a603def63344bfab2d33edeab301c5007e7de9f9f5b3885", size = 367351, upload-time = "2026-06-30T07:16:55.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ea/1bb734f314b8be319149ddee80b18bd41372bdcfbdf88d28131c0cd37719/rpds_py-2026.6.3-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:a9f4645593036b81bbdb36b9c8e0ea0d1c3fee968c4d59db0344c14087ef143a", size = 378827, upload-time = "2026-06-30T07:16:56.841Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/93/d9611e5b25e26df9a3649813ed66193ace9347a7c7fc4ab7cf70e94851c0/rpds_py-2026.6.3-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e55d236be29255554da47abe5c577637db7c24a02b8b46f0ca9524c855801868", size = 395966, upload-time = "2026-06-30T07:16:58.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/cb/99d77e16e5534ae1d90629bbe419ba6ee170833a6a85e3aa1cc41726fbbc/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:24e9c5386e16669b674a69c156c8eeefcb578f3b3397b713b08e6d60f3c7b187", size = 545680, upload-time = "2026-06-30T07:17:00.164Z" },
+    { url = "https://files.pythonhosted.org/packages/59/15/11a29755f790cef7a2f755e8e14f4f0c33f39489e1893a632a2eee59672b/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:c60924535c75f1566b6eb75b5c31a48a43fef04fa2d0d201acbad8a9969c6107", size = 611853, upload-time = "2026-06-30T07:17:01.962Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/0c27547e21644da938fb530f7e1a8148dd24d02db07e7a5f2567a17ce710/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:38a2fea2787428f811719ceb9114cb78964a3138838320c29ac39526c79c16ba", size = 573715, upload-time = "2026-06-30T07:17:03.693Z" },
+    { url = "https://files.pythonhosted.org/packages/29/71/4d8fcf700931815594bce892255bbd973b94efaf0fc1932b0590df18d886/rpds_py-2026.6.3-cp315-cp315-win32.whl", hash = "sha256:d483fe17f01ad64b7bf7cc38fcefff1ca9fb83f8c2b2542b68f97ffe0611b369", size = 202864, upload-time = "2026-06-30T07:17:05.746Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/62/b577562de0edbb55b2be85ce5fd09c33e386b9b13eee09833af4240fd5c4/rpds_py-2026.6.3-cp315-cp315-win_amd64.whl", hash = "sha256:67e3a721ffc5d8d2210d3671872298c4a84e4b8035cfe42ffd7cde35d772b146", size = 220430, upload-time = "2026-06-30T07:17:07.471Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/d6d0b2509825141eef60669a5739eec88dbc6a48053d6c92993a5704defe/rpds_py-2026.6.3-cp315-cp315-win_arm64.whl", hash = "sha256:6e84adbcf4bf841aed8116a8264b9f50b4cb3e7bd89b516122e616ac56ca269e", size = 215877, upload-time = "2026-06-30T07:17:09.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/f3ea278f0afd615c1d0f19cb69043a41526e2bb600c2b536eb192218eb27/rpds_py-2026.6.3-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:ae6dd8f10bd17aad820876d24caec9efdafd80a318d16c0a48edb5e136902c6b", size = 346933, upload-time = "2026-06-30T07:17:10.762Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/29/9907bdf1c5346763cf10b7f6852aad86652168c259def904cbe0082c5864/rpds_py-2026.6.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:bdbd97738551fca3917c1bd7188bec1920bb520104f28e7e1007f9ceb17b7690", size = 340274, upload-time = "2026-06-30T07:17:12.266Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/2c/8e03767b5778ef25cebf74a7a91a2c3806f8eced4c92cb7406bbe060756d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b95977e7211527ab0ba576e286d023389fbeeb32a6b7b771665d333c60e5342", size = 370763, upload-time = "2026-06-30T07:17:14.107Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e1/df2a7e1ba2efd796af26194250b8d42c821b46592311595162af9ef0528d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d15fde0e6fb0d88a60d221204873743e5d9f0b7d29165e62cd86d0413ad74ba6", size = 376467, upload-time = "2026-06-30T07:17:15.76Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/de/8a0814d1946af29cb068fb259aa8622f856df1d0bab58429448726b537f5/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a136d453475ac0fcbda502ef1e6504bd28d6d904700915d278deeab0d00fe140", size = 496689, upload-time = "2026-06-30T07:17:17.308Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f3/f19e0c852ba13694f5a79f3b719331051573cb5693feacf8a88ffffc3a71/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f826877d462181e5eb1c26a0026b8d0cab05d99844ecb6d8bf3627a2ca0c0442", size = 385340, upload-time = "2026-06-30T07:17:18.928Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/7ec3a9d2d4351f99e37bcb06b6b6f954512646bfdbf9742e1de727865daf/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79486287de1730dbaff3dbd124d0ca4d2ef7f9d29bf2544f1f93c09b5bcbbd12", size = 372179, upload-time = "2026-06-30T07:17:20.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ac/9cee911dff2aaa9a5a8354f6610bf2e6a616de9197c5fff4f54f82585f1e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:808345f53cb952433ca2816f1604ff3515608a81784954f38d4452acfe8e61d5", size = 379993, upload-time = "2026-06-30T07:17:22.212Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6b/7c2a07ba88d1e9a936612f7a5d067467ed03d971d5a06f7d309dff044a7e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1967debc37f64f2c4dc90a7f563aec558b471966e12adcac4e1c4240496b6ebf", size = 398909, upload-time = "2026-06-30T07:17:23.66Z" },
+    { url = "https://files.pythonhosted.org/packages/97/0b/776ffcb66783637b0031f6d58d6fb55913c8b5abf00aeecd46bf933fb477/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:f0840b5b17057f7fd918b76183a4b5a0635f43e14eb2ce60dce1d4ee4707ea00", size = 546584, upload-time = "2026-06-30T07:17:25.264Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/ba3bc04d7092bd553c9b2b195624992d2cc4f3de1f380b7b93cbee67bd79/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:faa679d19a6696fd54259ad321251ad77a13e70e03dd834daa762a44fb6196ef", size = 614357, upload-time = "2026-06-30T07:17:26.888Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/71/14edf065f04630b1a8472f7653cad03f6c478bcf95ea0e6aed55451e33ea/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:23a439f31ccbeff1574e24889128821d1f7917470e830cf6544dced1c662262a", size = 576533, upload-time = "2026-06-30T07:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/76/65002b08596c389105720a8c0d22298b8dc25a4baf89b2ce431343c8b1de/rpds_py-2026.6.3-cp315-cp315t-win32.whl", hash = "sha256:913ca42ccad3f8cc6e292b587ae8ae49c8c823e5dce51a736252fc7c7cdfa577", size = 201204, upload-time = "2026-06-30T07:17:30.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/97/d855d6b3c322d1f27e26f5241c42016b56cf01377ea8ed348285f54652f0/rpds_py-2026.6.3-cp315-cp315t-win_amd64.whl", hash = "sha256:ae3d4fe8c0b9213624fdce7279d70e3b148b682ca20719ebd193a23ebfa47324", size = 220719, upload-time = "2026-06-30T07:17:31.788Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/9c/f0d19ac587fd0e4ab6b72cda355e9c5a6166b01ef7e064e437aef8eb9fef/rpds_py-2026.6.3-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:4cf2d36a2357e4d07bb5a4f98801265327b48256867816cfd2ceb001e9754a8f", size = 349791, upload-time = "2026-06-30T07:17:33.315Z" },
+    { url = "https://files.pythonhosted.org/packages/38/c7/1d49d204c9fd2ee6c537601dc4c1ba921e03363ca576bfab94a00254ac9a/rpds_py-2026.6.3-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:30c6dc199b24a5e3e81d50da0f00858c5bbdb2617a750395687f4339c5818171", size = 352842, upload-time = "2026-06-30T07:17:34.897Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/e5/c0b5dc93cd0d4c06ce1f438907649514e2ea077bcd911e3154a51e96c38e/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9891e594296ab9dada6551c8e7b387b2721f27a67eecd528412e8906247a7b90", size = 382094, upload-time = "2026-06-30T07:17:36.514Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/54/ec0e907b4ca8d541112db352409bd15f871c9b243e0c92c9b5a46ae96f01/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b5c2dc92304aa48a4a60443b548bb12f12e119d4b72f314015e67b9e1be97fca", size = 388662, upload-time = "2026-06-30T07:17:38.235Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f4/921c22a4fd0f1c1ac13a3996ffbf0aa67951e2c8ad0d1d9574938a2932e8/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:127e08c0642d880cf32ca47ec2a4a77b901f7e2dd1ad9762adb13955d72ffcc9", size = 504896, upload-time = "2026-06-30T07:17:39.689Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/1b/a114b972cefa1ab1cdb3c7bb177cd3844a12826c507c722d3a73516dbbaf/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8bb68f03f395eb793220b45c097bd4d8c32944393da0fad8b999efac0868fc8c", size = 391545, upload-time = "2026-06-30T07:17:41.336Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/98/af9b3db77d47fcbe6c8c1f36e2c2147ec70292819e99c325f871584a1c11/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a3450b693fde92133e9f51060568a4c31fcca76d5e53bbd611e689ca446517e9", size = 380059, upload-time = "2026-06-30T07:17:42.857Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ba/0efd8668b97c1d26a61566386c636a7a7a09829e474fdf807caa15a2c844/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:5e8d07bddee435a2ff6f1920e18feff28d0bc4533e42f4bf6927fbd073312c41", size = 393235, upload-time = "2026-06-30T07:17:44.637Z" },
+    { url = "https://files.pythonhosted.org/packages/62/90/8c139ee9690f73b0829f32647de6f40d826f8f443af6fa72644f96351aac/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3a83ae6c67b7676b9878378547ca8e93ed77a580037bcbcd1d32f739e1e6089c", size = 413008, upload-time = "2026-06-30T07:17:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/0043896fdd7828ce09a1d9a8b06433714d0960fc4ff3fc4aa72b666b764e/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:2bfd04c19ddbd6640de0b51894d764bd2758854d5b75bd102d2ef10cb9c293a9", size = 558118, upload-time = "2026-06-30T07:17:47.759Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/40/02355f0e134f783a8f9814c4680a1bd311d37671577a5964ea838573ff37/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:ca6546b66be9dc4738b1b043d5ebd5488c66c578c5ff0fd0e8065313fe3afb76", size = 623138, upload-time = "2026-06-30T07:17:49.355Z" },
+    { url = "https://files.pythonhosted.org/packages/10/85/48f0abdcef5cce4e034c7a5b0ceeceba0b01bf0d942824f4bb720afe2dec/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:8e65860d238379ed982fd9ba690579b5e95af2f4840f99c772816dbe573cb826", size = 586486, upload-time = "2026-06-30T07:17:51.141Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR fixes OpenAPI schema generation by switching from the built-in DRF OpenAPI schema generator to [drf-spectacular](https://drf-spectacular.readthedocs.io/en/latest/readme.html), as outlined in #627.

By using drf-spectacular, we get the following endpoints:


- `/docs`: Swagger UI for viewing the schema (default).
- `/docs/redoc`: ReDoc UI for viewing the schema (alternative).
- `/docs/schema`: The OpenAPI schema (YAML file) (`/docs` kept for backwards compatibility).

Since we can't assume MREG can access the internet to fetch static files for serving swagger/redoc UI pages, we include them manually via the `drf-spectacular[sidecar]` extra. Because both Swagger and ReDoc static files come from the same package, including endpoints for both costs nothing extra in terms of final container image size.

## Issues

Using drf-spectacular highlights numerous issues with our views:

<details>
  <summary><code>❯ uv run ./manage.py spectacular --color --file schema.yml</code></summary>

```
mreg/api/views.py:264: Error [HealthHeartbeat]: unable to guess serializer. This is graceful fallback handling for APIViews. Consider using GenericAPIView as view base class, if view is under your control. Either way you may want to add a serializer_class (or method). Ignoring view for now.
mreg/api/views.py:274: Error [HealthLDAP]: unable to guess serializer. This is graceful fallback handling for APIViews. Consider using GenericAPIView as view base class, if view is under your control. Either way you may want to add a serializer_class (or method). Ignoring view for now.
mreg/api/views.py:243: Error [MetaVersions]: unable to guess serializer. This is graceful fallback handling for APIViews. Consider using GenericAPIView as view base class, if view is under your control. Either way you may want to add a serializer_class (or method). Ignoring view for now.
mreg/api/views.py:315: Error [MetricsView]: unable to guess serializer. This is graceful fallback handling for APIViews. Consider using GenericAPIView as view base class, if view is under your control. Either way you may want to add a serializer_class (or method). Ignoring view for now.
mreg/api/views.py:161: Error [UserInfo]: unable to guess serializer. This is graceful fallback handling for APIViews. Consider using GenericAPIView as view base class, if view is under your control. Either way you may want to add a serializer_class (or method). Ignoring view for now.
mreg/api/views.py:233: Error [MregVersion]: unable to guess serializer. This is graceful fallback handling for APIViews. Consider using GenericAPIView as view base class, if view is under your control. Either way you may want to add a serializer_class (or method). Ignoring view for now.
mreg/api/views.py:150: Error [TokenIsValid]: unable to guess serializer. This is graceful fallback handling for APIViews. Consider using GenericAPIView as view base class, if view is under your control. Either way you may want to add a serializer_class (or method). Ignoring view for now.
mreg/api/views.py:140: Error [TokenLogout]: unable to guess serializer. This is graceful fallback handling for APIViews. Consider using GenericAPIView as view base class, if view is under your control. Either way you may want to add a serializer_class (or method). Ignoring view for now.
mreg/api/v1/serializers.py:252: Warning [BACnetIDList > BACnetIDSerializer]: unable to resolve type hint for function "hostname". Consider using a type hint or @extend_schema_field. Defaulting to string.
mreg/api/v1/serializers.py:252: Warning [BACnetIDDetail > BACnetIDSerializer]: unable to resolve type hint for function "hostname". Consider using a type hint or @extend_schema_field. Defaulting to string.
mreg/api/v1/views.py: Error [dhcp_hosts_by_range]: unable to guess serializer. This is graceful fallback handling for APIViews. Consider using GenericAPIView as view base class, if view is under your control. Either way you may want to add a serializer_class (or method). Ignoring view for now.
mreg/api/v1/views.py: Warning [dhcp_hosts_by_range]: could not derive type of path parameter "ip" because it is untyped and obtaining queryset from the viewset failed. Consider adding a type to the path (e.g. <int:ip>) or annotating the parameter type with @extend_schema. Defaulting to "string".
mreg/api/v1/views.py: Warning [dhcp_hosts_by_range]: could not derive type of path parameter "range" because it is untyped and obtaining queryset from the viewset failed. Consider adding a type to the path (e.g. <int:range>) or annotating the parameter type with @extend_schema. Defaulting to "string".
mreg/api/v1/views.py: Error [dhcp_hosts_all_v4]: unable to guess serializer. This is graceful fallback handling for APIViews. Consider using GenericAPIView as view base class, if view is under your control. Either way you may want to add a serializer_class (or method). Ignoring view for now.
mreg/api/v1/views.py: Error [dhcp_hosts_all_v6]: unable to guess serializer. This is graceful fallback handling for APIViews. Consider using GenericAPIView as view base class, if view is under your control. Either way you may want to add a serializer_class (or method). Ignoring view for now.
mreg/api/v1/views.py:1228: Error [DhcpHostsV4ByV6]: unable to guess serializer. This is graceful fallback handling for APIViews. Consider using GenericAPIView as view base class, if view is under your control. Either way you may want to add a serializer_class (or method). Ignoring view for now.
mreg/api/v1/views.py:1228: Warning [DhcpHostsV4ByV6]: could not derive type of path parameter "ip" because it is untyped and obtaining queryset from the viewset failed. Consider adding a type to the path (e.g. <int:ip>) or annotating the parameter type with @extend_schema. Defaulting to "string".
mreg/api/v1/views.py:1228: Warning [DhcpHostsV4ByV6]: could not derive type of path parameter "range" because it is untyped and obtaining queryset from the viewset failed. Consider adding a type to the path (e.g. <int:range>) or annotating the parameter type with @extend_schema. Defaulting to "string".
mreg/api/v1/views_hostgroups.py:119: Warning [HostGroupGroupsList]: could not derive type of path parameter "name" because it is untyped and obtaining queryset from the viewset failed. Consider adding a type to the path (e.g. <int:name>) or annotating the parameter type with @extend_schema. Defaulting to "string".
mreg/api/v1/views_hostgroups.py:119: Warning [HostGroupGroupsList]: Failed to obtain model through view's queryset due to raised exception. Prevent this either by setting "queryset = Model.objects.none()" on the view, checking for "getattr(self, "swagger_fake_view", False)" in get_queryset() or by simply using @extend_schema. (Exception: 'name')
mreg/api/v1/views_hostgroups.py:133: Warning [HostGroupGroupsDetail]: could not derive type of path parameter "name" because it is untyped and obtaining queryset from the viewset failed. Consider adding a type to the path (e.g. <int:name>) or annotating the parameter type with @extend_schema. Defaulting to "string".
mreg/api/v1/views_hostgroups.py:133: Warning [HostGroupGroupsDetail]: could not derive type of path parameter "group" because it is untyped and obtaining queryset from the viewset failed. Consider adding a type to the path (e.g. <int:group>) or annotating the parameter type with @extend_schema. Defaulting to "string".
mreg/api/v1/views_hostgroups.py:150: Warning [HostGroupHostsList]: could not derive type of path parameter "name" because it is untyped and obtaining queryset from the viewset failed. Consider adding a type to the path (e.g. <int:name>) or annotating the parameter type with @extend_schema. Defaulting to "string".
mreg/api/v1/views_hostgroups.py:150: Warning [HostGroupHostsList]: Failed to obtain model through view's queryset due to raised exception. Prevent this either by setting "queryset = Model.objects.none()" on the view, checking for "getattr(self, "swagger_fake_view", False)" in get_queryset() or by simply using @extend_schema. (Exception: 'name')
mreg/api/v1/views_hostgroups.py:164: Warning [HostGroupHostsDetail]: could not derive type of path parameter "name" because it is untyped and obtaining queryset from the viewset failed. Consider adding a type to the path (e.g. <int:name>) or annotating the parameter type with @extend_schema. Defaulting to "string".
mreg/api/v1/views_hostgroups.py:164: Warning [HostGroupHostsDetail]: could not derive type of path parameter "host" because it is untyped and obtaining queryset from the viewset failed. Consider adding a type to the path (e.g. <int:host>) or annotating the parameter type with @extend_schema. Defaulting to "string".
mreg/api/v1/views_hostgroups.py:181: Warning [HostGroupOwnersList]: could not derive type of path parameter "name" because it is untyped and obtaining queryset from the viewset failed. Consider adding a type to the path (e.g. <int:name>) or annotating the parameter type with @extend_schema. Defaulting to "string".
mreg/api/v1/views_hostgroups.py:181: Warning [HostGroupOwnersList]: Failed to obtain model through view's queryset due to raised exception. Prevent this either by setting "queryset = Model.objects.none()" on the view, checking for "getattr(self, "swagger_fake_view", False)" in get_queryset() or by simply using @extend_schema. (Exception: 'name')
mreg/api/v1/views_hostgroups.py:196: Warning [HostGroupOwnersDetail]: could not derive type of path parameter "name" because it is untyped and obtaining queryset from the viewset failed. Consider adding a type to the path (e.g. <int:name>) or annotating the parameter type with @extend_schema. Defaulting to "string".
mreg/api/v1/views_hostgroups.py:196: Warning [HostGroupOwnersDetail]: could not derive type of path parameter "owner" because it is untyped and obtaining queryset from the viewset failed. Consider adding a type to the path (e.g. <int:owner>) or annotating the parameter type with @extend_schema. Defaulting to "string".
hostpolicy/api/v1/views.py:174: Warning [HostPolicyRoleAtomsList]: could not derive type of path parameter "name" because it is untyped and obtaining queryset from the viewset failed. Consider adding a type to the path (e.g. <int:name>) or annotating the parameter type with @extend_schema. Defaulting to "string".
hostpolicy/api/v1/views.py:174: Warning [HostPolicyRoleAtomsList]: Failed to obtain model through view's queryset due to raised exception. Prevent this either by setting "queryset = Model.objects.none()" on the view, checking for "getattr(self, "swagger_fake_view", False)" in get_queryset() or by simply using @extend_schema. (Exception: 'name')
hostpolicy/api/v1/views.py:188: Warning [HostPolicyRoleAtomsDetail]: could not derive type of path parameter "name" because it is untyped and obtaining queryset from the viewset failed. Consider adding a type to the path (e.g. <int:name>) or annotating the parameter type with @extend_schema. Defaulting to "string".
hostpolicy/api/v1/views.py:188: Warning [HostPolicyRoleAtomsDetail]: could not derive type of path parameter "atom" because it is untyped and obtaining queryset from the viewset failed. Consider adding a type to the path (e.g. <int:atom>) or annotating the parameter type with @extend_schema. Defaulting to "string".
hostpolicy/api/v1/views.py:205: Warning [HostPolicyRoleHostsList]: could not derive type of path parameter "name" because it is untyped and obtaining queryset from the viewset failed. Consider adding a type to the path (e.g. <int:name>) or annotating the parameter type with @extend_schema. Defaulting to "string".
hostpolicy/api/v1/views.py:205: Warning [HostPolicyRoleHostsList]: Failed to obtain model through view's queryset due to raised exception. Prevent this either by setting "queryset = Model.objects.none()" on the view, checking for "getattr(self, "swagger_fake_view", False)" in get_queryset() or by simply using @extend_schema. (Exception: 'name')
hostpolicy/api/v1/views.py:219: Warning [HostPolicyRoleHostsDetail]: could not derive type of path parameter "name" because it is untyped and obtaining queryset from the viewset failed. Consider adding a type to the path (e.g. <int:name>) or annotating the parameter type with @extend_schema. Defaulting to "string".
hostpolicy/api/v1/views.py:219: Warning [HostPolicyRoleHostsDetail]: could not derive type of path parameter "host" because it is untyped and obtaining queryset from the viewset failed. Consider adding a type to the path (e.g. <int:host>) or annotating the parameter type with @extend_schema. Defaulting to "string".
mreg/api/v1/serializers.py:33: Warning [HostList > HostSerializer > HostCommunityMappingSerializer > CommunitySerializer]: unable to resolve type hint for function "get_hosts". Consider using a type hint or @extend_schema_field. Defaulting to string.
mreg/api/v1/serializers.py:33: Warning [HostList > HostSerializer > HostCommunityMappingSerializer > CommunitySerializer]: unable to resolve type hint for function "get_global_name". Consider using a type hint or @extend_schema_field. Defaulting to string.
mreg/api/v1/views.py:494: Error [HostContactsView]: unable to guess serializer. This is graceful fallback handling for APIViews. Consider using GenericAPIView as view base class, if view is under your control. Either way you may want to add a serializer_class (or method). Ignoring view for now.
mreg/api/v1/views.py:494: Warning [HostContactsView]: could not derive type of path parameter "name" because it is untyped and obtaining queryset from the viewset failed. Consider adding a type to the path (e.g. <int:name>) or annotating the parameter type with @extend_schema. Defaulting to "string".
mreg/api/v1/serializers.py:819: Error [NetworkList > NetworkSerializer]: could not resolve model field "mreg.Network.network". Failed to resolve through serializer_field_mapping, get_internal_type(), or any override mechanism. Defaulting to "string"
mreg/api/v1/serializers.py:819: Error [NetworkDetail > NetworkSerializer]: could not resolve model field "mreg.Network.network". Failed to resolve through serializer_field_mapping, get_internal_type(), or any override mechanism. Defaulting to "string"
mreg/api/v1/serializers.py:33: Warning [NetworkCommunityDetail > CommunitySerializer]: unable to resolve type hint for function "get_hosts". Consider using a type hint or @extend_schema_field. Defaulting to string.
mreg/api/v1/serializers.py:33: Warning [NetworkCommunityDetail > CommunitySerializer]: unable to resolve type hint for function "get_global_name". Consider using a type hint or @extend_schema_field. Defaulting to string.
mreg/api/v1/views_network_policy.py:218: Warning [NetworkCommunityHostList]: Failed to obtain model through view's queryset due to raised exception. Prevent this either by setting "queryset = Model.objects.none()" on the view, checking for "getattr(self, "swagger_fake_view", False)" in get_queryset() or by simply using @extend_schema. (Exception: Network not found.)
mreg/api/v1/views.py:961: Warning [NetworkExcludedRangeList]: Failed to obtain model through view's queryset due to raised exception. Prevent this either by setting "queryset = Model.objects.none()" on the view, checking for "getattr(self, "swagger_fake_view", False)" in get_queryset() or by simply using @extend_schema. (Exception: 'network')
mreg/api/v1/views.py: Error [network_first_unused]: unable to guess serializer. This is graceful fallback handling for APIViews. Consider using GenericAPIView as view base class, if view is under your control. Either way you may want to add a serializer_class (or method). Ignoring view for now.
mreg/api/v1/views.py: Error [network_ptroverride_host_list]: unable to guess serializer. This is graceful fallback handling for APIViews. Consider using GenericAPIView as view base class, if view is under your control. Either way you may want to add a serializer_class (or method). Ignoring view for now.
mreg/api/v1/views.py: Error [network_ptroverride_list]: unable to guess serializer. This is graceful fallback handling for APIViews. Consider using GenericAPIView as view base class, if view is under your control. Either way you may want to add a serializer_class (or method). Ignoring view for now.
mreg/api/v1/views.py: Error [network_random_unused]: unable to guess serializer. This is graceful fallback handling for APIViews. Consider using GenericAPIView as view base class, if view is under your control. Either way you may want to add a serializer_class (or method). Ignoring view for now.
mreg/api/v1/views.py: Error [network_reserved_list]: unable to guess serializer. This is graceful fallback handling for APIViews. Consider using GenericAPIView as view base class, if view is under your control. Either way you may want to add a serializer_class (or method). Ignoring view for now.
mreg/api/v1/views.py: Error [network_unused_count]: unable to guess serializer. This is graceful fallback handling for APIViews. Consider using GenericAPIView as view base class, if view is under your control. Either way you may want to add a serializer_class (or method). Ignoring view for now.
mreg/api/v1/views.py: Error [network_unused_list]: unable to guess serializer. This is graceful fallback handling for APIViews. Consider using GenericAPIView as view base class, if view is under your control. Either way you may want to add a serializer_class (or method). Ignoring view for now.
mreg/api/v1/views.py: Error [network_used_count]: unable to guess serializer. This is graceful fallback handling for APIViews. Consider using GenericAPIView as view base class, if view is under your control. Either way you may want to add a serializer_class (or method). Ignoring view for now.
mreg/api/v1/views.py: Error [network_used_host_list]: unable to guess serializer. This is graceful fallback handling for APIViews. Consider using GenericAPIView as view base class, if view is under your control. Either way you may want to add a serializer_class (or method). Ignoring view for now.
mreg/api/v1/views.py: Error [network_used_list]: unable to guess serializer. This is graceful fallback handling for APIViews. Consider using GenericAPIView as view base class, if view is under your control. Either way you may want to add a serializer_class (or method). Ignoring view for now.
mreg/api/v1/views.py: Error [network_by_ip]: unable to guess serializer. This is graceful fallback handling for APIViews. Consider using GenericAPIView as view base class, if view is under your control. Either way you may want to add a serializer_class (or method). Ignoring view for now.
mreg/api/v1/views.py: Warning [network_by_ip]: could not derive type of path parameter "ip" because it is untyped and obtaining queryset from the viewset failed. Consider adding a type to the path (e.g. <int:ip>) or annotating the parameter type with @extend_schema. Defaulting to "string".
mreg/api/v1/serializers.py:582: Error [NetGroupRegexPermissionList > NetGroupRegexPermissionSerializer]: could not resolve model field "mreg.NetGroupRegexPermission.range". Failed to resolve through serializer_field_mapping, get_internal_type(), or any override mechanism. Defaulting to "string"
mreg/api/v1/serializers.py:582: Error [NetGroupRegexPermissionDetail > NetGroupRegexPermissionSerializer]: could not resolve model field "mreg.NetGroupRegexPermission.range". Failed to resolve through serializer_field_mapping, get_internal_type(), or any override mechanism. Defaulting to "string"
mreg/api/v1/views_zones.py: Error [zone_file_detail]: unable to guess serializer. This is graceful fallback handling for APIViews. Consider using GenericAPIView as view base class, if view is under your control. Either way you may want to add a serializer_class (or method). Ignoring view for now.
mreg/api/v1/views_zones.py:153: Warning [ForwardZoneDelegationList]: Failed to obtain model through view's queryset due to raised exception. Prevent this either by setting "queryset = Model.objects.none()" on the view, checking for "getattr(self, "swagger_fake_view", False)" in get_queryset() or by simply using @extend_schema. (Exception: 'name')
mreg/api/v1/views_zones.py: Error [forward_zone_by_hostname]: unable to guess serializer. This is graceful fallback handling for APIViews. Consider using GenericAPIView as view base class, if view is under your control. Either way you may want to add a serializer_class (or method). Ignoring view for now.
mreg/api/v1/views_zones.py: Warning [forward_zone_by_hostname]: could not derive type of path parameter "hostname" because it is untyped and obtaining queryset from the viewset failed. Consider adding a type to the path (e.g. <int:hostname>) or annotating the parameter type with @extend_schema. Defaulting to "string".
mreg/api/v1/views_zones.py:159: Warning [ReverseZoneDelegationList]: Failed to obtain model through view's queryset due to raised exception. Prevent this either by setting "queryset = Model.objects.none()" on the view, checking for "getattr(self, "swagger_fake_view", False)" in get_queryset() or by simply using @extend_schema. (Exception: 'name')
Warning: operationId "api_v1_dhcphosts_ipv6byipv4_retrieve" has collisions [('/api/v1/dhcphosts/ipv6byipv4/', 'get'), ('/api/v1/dhcphosts/ipv6byipv4/{ip}/{range}', 'get')]. resolving with numeral suffixes.

Schema generation summary:
Warnings: 75 (38 unique)
Errors:   119 (30 unique)
```

</details>