### PR TITLE
Fix local settings not configuring DB correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ mreg supports configuration via environment variables with the `MREG_` prefix. T
 
 | Variable | Default | Description |
 | -------- | ------- | ----------- |
+| `MREG_DB_POOL_ENABLED` | `True` | Enable or disable database connection pooling |
 | `MREG_DB_POOL_MIN_SIZE` | `5` | Minimum idle connections in pool |
 | `MREG_DB_POOL_MAX_SIZE` | `25` | Maximum connections in pool |
 | `MREG_DB_POOL_MAX_IDLE` | `300` | Max idle time before closing (seconds) |
@@ -209,19 +210,25 @@ docker run --network host \
 ## Local Settings
 
 To override entries in `mregsite/settings.py`, create a file `mregsite/local_settings.py` and add the entries there.
-For example, the default database setup in `settings.py` uses sqlite3, but if you set up your postgres database
-you'll want to override this when testing. To to this, just add the following to your `local_settings.py` file:
 
 ```python
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'mreg_sample',
-        'USER': 'mreg_user',
-        'PASSWORD': 'mregdbpass',
-        'HOST': 'localhost',
-    }
-}
+MREG_DB_NAME = "mreg_sample"
+MREG_DB_USER = "mreg_user"
+MREG_DB_PASSWORD = "mregdbpass"
+MREG_DB_HOST = "localhost"
+MREG_DB_PORT = "5432"
+```
+
+The default database setup in `settings.py` uses Django's postgres connection pool, but if you want to disable pooling for local development, you can set `MREG_DB_USE_POOL` to `False` in `local_settings.py`:
+
+```python
+MREG_DB_USE_POOL = False
+```
+
+or via environment variable:
+
+```bash
+export MREG_DB_USE_POOL=False
 ```
 
 ## Contributing

--- a/local-docker-psql.MD
+++ b/local-docker-psql.MD
@@ -23,14 +23,9 @@ EOF
 Finally add settings to django::
 ```
 cat >> mregsite/local_settings.py << EOF
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'mreg',
-        'USER': 'mreg',
-        'PASSWORD': 'mregpass',
-        'HOST': 'localhost',
-    }
-}
+MREG_DB_NAME = "mreg"
+MREG_DB_USER = "mreg"
+MREG_DB_PASSWORD = "mregpass"
+MREG_DB_HOST = "localhost"
 EOF
 ```

--- a/mreg/tests/test_settings.py
+++ b/mreg/tests/test_settings.py
@@ -1,0 +1,20 @@
+from unittest.mock import patch
+from mregsite import settings
+
+from django.test import TestCase
+
+
+class SettingsTestCase(TestCase):
+    """This class defines the test suite for settings.py."""
+
+    def test_get_pool_settings_enabled(self):
+        with patch.object(settings, "MREG_DB_POOL_ENABLED", True):
+            result = settings.get_pool_settings()
+        assert isinstance(result, dict)
+        assert "max_size" in result
+
+
+    def test_get_pool_settings_disabled(self):
+        with patch.object(settings, "MREG_DB_POOL_ENABLED", False):
+            result = settings.get_pool_settings()
+        assert result is False

--- a/mregsite/settings.py
+++ b/mregsite/settings.py
@@ -13,7 +13,7 @@ https://docs.djangoproject.com/en/2.0/ref/settings/
 import logging.config
 import os
 import sys
-from typing import TypeVar
+from typing import Literal, TypeVar
 
 import structlog
 
@@ -133,6 +133,7 @@ MREG_DB_PASSWORD = envvar("MREG_DB_PASSWORD", "")
 MREG_DB_HOST = envvar("MREG_DB_HOST", "localhost")
 MREG_DB_PORT = envvar("MREG_DB_PORT", "5432")
 
+MREG_DB_POOL_ENABLED = envvar("MREG_DB_POOL_ENABLED", True)
 MREG_DB_POOL_MIN_SIZE = envvar("MREG_DB_POOL_MIN_SIZE", 5)
 MREG_DB_POOL_MAX_SIZE = envvar("MREG_DB_POOL_MAX_SIZE", 25)
 MREG_DB_POOL_MAX_IDLE = envvar("MREG_DB_POOL_MAX_IDLE", 300)
@@ -237,29 +238,6 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "mregsite.wsgi.application"
 
-DATABASES = {
-    "default": {
-        "ENGINE": MREG_DB_ENGINE,
-        "NAME": MREG_DB_NAME,
-        "USER": MREG_DB_USER,
-        "PASSWORD": MREG_DB_PASSWORD,
-        "HOST": MREG_DB_HOST,        
-        "PORT": MREG_DB_PORT,
-        "CONN_MAX_AGE": 0,  # Let the pool manage connection lifecycle
-        "OPTIONS": {
-            # Native psycopg3 connection pooling (Django 5.2+)
-            "pool": {
-                "max_size": MREG_DB_POOL_MAX_SIZE,  # Maximum connections in the pool
-                "min_size": MREG_DB_POOL_MIN_SIZE,  # Minimum idle connections to maintain
-                "max_idle": MREG_DB_POOL_MAX_IDLE,  # Max idle time before connection is closed (seconds)
-                "max_lifetime": MREG_DB_POOL_MAX_LIFETIME,  # Max connection lifetime (seconds)
-            },
-            # psycopg3 connection parameters
-            "connect_timeout": MREG_DB_PSYCOPG_CONNECT_TIMEOUT,  # 5 second timeout for initial connection
-            "options": MREG_DB_PSYCOPG_OPTIONS,  # 30 second statement timeout
-        },
-    }
-}
 
 
 # Password validation
@@ -454,3 +432,38 @@ if TESTING or "CI" in os.environ:
     HOSTPOLICYADMIN_GROUP = "default-hostpolicyadmin-group"
     DNS_WILDCARD_GROUP = "default-dns-wildcard-group"
     DNS_UNDERSCORE_GROUP = "default-dns-underscore-group"
+
+
+def get_pool_settings() -> dict[str, int] | Literal[False]:
+    """Get the connection pool settings for psycopg3, or False if pooling is disabled."""
+    if not MREG_DB_POOL_ENABLED:
+        return False
+    return {
+        "max_size": MREG_DB_POOL_MAX_SIZE,  # Maximum connections in the pool
+        "min_size": MREG_DB_POOL_MIN_SIZE,  # Minimum idle connections to maintain
+        "max_idle": MREG_DB_POOL_MAX_IDLE,  # Max idle time before connection is closed (seconds)
+        "max_lifetime": MREG_DB_POOL_MAX_LIFETIME,  # Max connection lifetime (seconds)
+    }
+
+# Compatibility hack for older local_settings.py files that define the
+# DATABASES setting directly instead of using the MREG_DB_* variables.
+# Thus, we only set DATABASES if it hasn't already been defined.
+if "DATABASES" not in globals():
+    DATABASES = {
+        "default": {
+            "ENGINE": MREG_DB_ENGINE,
+            "NAME": MREG_DB_NAME,
+            "USER": MREG_DB_USER,
+            "PASSWORD": MREG_DB_PASSWORD,
+            "HOST": MREG_DB_HOST,        
+            "PORT": MREG_DB_PORT,
+            "CONN_MAX_AGE": 0,  # Let the pool manage connection lifecycle
+            "OPTIONS": {
+                # Native psycopg3 connection pooling (Django 5.2+)
+                "pool": get_pool_settings(),
+                # psycopg3 connection parameters
+                "connect_timeout": MREG_DB_PSYCOPG_CONNECT_TIMEOUT,  # 5 second timeout for initial connection
+                "options": MREG_DB_PSYCOPG_OPTIONS,  # 30 second statement timeout
+            },
+        }
+    }


### PR DESCRIPTION
## Problem

The instructions in [README.md](https://github.com/unioslo/mreg/blob/bc8b6fa974b714d69c5198d38d4ab8cf6f77beb0/README.md#local-settings) and [local-docker-psql.MD](https://github.com/unioslo/mreg/blob/bc8b6fa974b714d69c5198d38d4ab8cf6f77beb0/local-docker-psql.MD) state that `DATABASES` should be redefined in order to use custom configurations. For most environments, this is overkill and actively harmful if not done correctly, as it overrides the default settings for activating [database connection pooling](https://docs.djangoproject.com/en/6.0/ref/databases/#connection-pool), which we define in settings.py:

https://github.com/unioslo/mreg/blob/bc8b6fa974b714d69c5198d38d4ab8cf6f77beb0/mregsite/settings.py#L240-L262

## Changes

This PR rewrites the documentation to use variable overrides in `local_settings.py` instead of redefining the entire database configuration. Furthermore, it moves the definition of `DATABASES` until after `local_settings.py` has been imported.

### Backwards compatibility

Backwards compatibility for older `local_settings.py` config files that define `DATABASES` has been added to prevent overriding those configurations with defaults:

https://github.com/unioslo/mreg/blob/e91b5c850d7cb6612cf773ca6287bdc7de6bb0d0/mregsite/settings.py#L451-L452