### PR TITLE
Add optional profiling capabilities with django-silk

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,36 @@ or via environment variable:
 export MREG_DB_USE_POOL=False
 ```
 
+## Profiling
+
+mreg supports request and query profiling via [django-silk](https://github.com/jazzband/django-silk). Silk is an optional dependency in the `profile` dependency group (and also a part of the `dev` dependency group, thus is installed automatically in development environments). When enabled, Silk provides detailed insights into request performance, including SQL query analysis and optionally cProfile-based profiling of Python code.
+
+When enabled, Silk results are accessible in the web interface at http://127.0.0.1:8000/silk/ by default.
+
+### Enabling profiling
+
+Silk is included in the `dev` dependency group and is available automatically after `uv sync`. For deployments that need it without the full dev group (e.g. a profiling-enabled container image), use `uv sync --only-group profile`.
+
+Set `MREG_PROFILING_ENABLED=True` to activate Silk instrumentation. When enabled, Silk records every request and its associated SQL queries, which are viewable at `/silk/`.
+
+> [!WARNING]
+> Profiling adds overhead to every request. Only enable it in development or controlled environments, never in production.
+
+### Profiling configuration
+
+| Variable | Default | Description |
+| -------- | ------- | ----------- |
+| `MREG_PROFILING_ENABLED` | `False` | Enable Silk request/query instrumentation |
+| `MREG_SILKY_PYTHON_PROFILER` | `True` | Use cProfile for detailed per-request profiling (requires `MREG_PROFILING_ENABLED`) |
+| `MREG_SILKY_PYTHON_PROFILER_BINARY` | `True` | Save cProfile results to disk as `.prof` files for offline analysis |
+| `MREG_SILKY_PYTHON_PROFILER_RESULT_PATH` | `silk/profiles` | Directory to write `.prof` files into |
+| `MREG_SILKY_META` | `False` | Enable Silk meta-profiling (measures Silk's own overhead) |
+
+When `MREG_SILKY_PYTHON_PROFILER` is disabled, Silk still collects request/response data and timings, but not the detailed call-level profiling information.
+
+The `.prof` files written to `MREG_SILKY_PYTHON_PROFILER_RESULT_PATH` are standard cProfile format and can be opened with tools like `snakeviz` or Python's `pstats` module, in addition to the Silk UI.
+
+
 ## Contributing
 
 Patches and PRs are welcome. However, there are a number of intricacies in both code structure and internal

--- a/hostpolicy/signals.py
+++ b/hostpolicy/signals.py
@@ -1,5 +1,6 @@
 from django.db.models.signals import m2m_changed, pre_delete, pre_save, post_save, post_delete
 from django.dispatch import receiver
+from django.utils import timezone
 
 from .models import HostPolicyAtom, HostPolicyRole
 from mreg.models.host import Host
@@ -19,8 +20,7 @@ def role_update_updated_at_on_changes(sender, instance, action, model,
 
 
 def _hostpolicyatom_update_m2m_relations(instance):
-    for role in instance.roles.all():
-        role.save()
+    instance.roles.all().update(updated_at=timezone.now())
 
 
 @receiver(pre_save, sender=HostPolicyAtom)

--- a/mreg/api/urls.py
+++ b/mreg/api/urls.py
@@ -13,3 +13,4 @@ urlpatterns = [
     path('meta/health/heartbeat', views.HealthHeartbeat.as_view()),
     path('meta/health/ldap', views.HealthLDAP.as_view()),
 ]
+

--- a/mregsite/settings.py
+++ b/mregsite/settings.py
@@ -582,10 +582,10 @@ if MREG_PROFILING_ENABLED:
             try:
                 p.mkdir(parents=True)
             except OSError as e:
-                print(f"Failed to create Silk profiler result directory {SILKY_PYTHON_PROFILER_RESULT_PATH}: {e}", file=sys.stderr)
+                logger.error(f"Failed to create Silk profiler result directory {SILKY_PYTHON_PROFILER_RESULT_PATH}: {e}")
                 sys.exit(1)
         elif not p.is_dir() or not os.access(p, os.W_OK):
-            print(f"Silk profiler result path {SILKY_PYTHON_PROFILER_RESULT_PATH} is not a writable directory.", file=sys.stderr)
+            logger.error(f"Silk profiler result path {SILKY_PYTHON_PROFILER_RESULT_PATH} is not a writable directory.")
             sys.exit(1)
 
     INSTALLED_APPS.append("silk")

--- a/mregsite/settings.py
+++ b/mregsite/settings.py
@@ -49,8 +49,8 @@ def envvar(var: str, default: DefaultT) -> DefaultT:
     except (ValueError, TypeError):
         return default
 
-def parse_protected_attrs(raw: str) -> list[dict]:
-    out: list[dict] = []
+def parse_protected_attrs(raw: str) -> list[dict[str, str]]:
+    out: list[dict[str, str]] = []
     for part in raw.split(","):
         part = part.strip()
         if not part:
@@ -419,93 +419,27 @@ structlog.configure(
     cache_logger_on_first_use=True,
 )
 
-# Django Silk profiling settings
+# Django Silk profiling and request inspection settings
 try:
     import silk  # noqa: F401  # pyright: ignore[reportUnusedImport, reportMissingTypeStubs]
     _silk_installed = True
 except ImportError:
     _silk_installed = False
 
-if MREG_PROFILING_ENABLED := envvar("MREG_PROFILING_ENABLED", False):
-    if not _silk_installed:
-        print("MREG_PROFILING_ENABLED is set to True, but silk is not installed. Please install silk or disable profiling.")
-        sys.exit(1)
-    print("Profiling is enabled. All requests will be profiled with Silk. This may have a performance impact.")
-    SILKY_DYNAMIC_PROFILING = [
-        {
-            "module": "mreg.api.v1.views",
-            "function": "HostDetail.get",
-            'name': 'Get single host',
-        },
-        {
-            "module": "mreg.api.v1.views",
-            "function": "HostList.get",
-            'name': 'Get hosts',
-        },
-        {
-            "module": "mreg.api.v1.views",
-            "function": "HostList.post",
-            'name': 'Create host',
-        },
-        {
-            "module": "hostpolicy.api.v1.views",
-            "function": "HostPolicyAtomDetail.get",
-            'name': 'Get single Atom',
-        },
-        {
-            "module": "hostpolicy.api.v1.views",
-            "function": "HostPolicyAtomDetail.delete",
-            'name': 'Delete single Atom',
-        },
-        {
-            "module": "hostpolicy.api.v1.views",
-            "function": "HostPolicyAtomList.get",
-            'name': 'Get Atoms',
-        },
-        {
-            "module": "hostpolicy.api.v1.views",
-            "function": "HostPolicyAtomList.post",
-            'name': 'Create Atom',
-        },
-        {
-            "module": "hostpolicy.api.v1.views",
-            "function": "HostPolicyRoleDetail.get",
-            'name': 'Get single Role',
-        },
-        {
-            "module": "hostpolicy.api.v1.views",
-            "function": "HostPolicyRoleDetail.delete",
-            'name': 'Delete a single Role',
-        },
-        {
-            "module": "hostpolicy.api.v1.views",
-            "function": "HostPolicyRoleList.get",
-            'name': 'Get Roles',
-        },
-        {
-            "module": "hostpolicy.api.v1.views",
-            "function": "HostPolicyRoleList.post",
-            'name': 'Create Role',
-        },
-        {
-            "module": "hostpolicy.api.v1.views",
-            "function": "HostPolicyRoleAtomsList.get",
-            'name': 'Get Role Atoms',
-        },
-        {
-            "module": "hostpolicy.api.v1.views",
-            "function": "HostPolicyRoleHostsList.get",
-            'name': 'Get Role Hosts',
-        },
-    ]
-    
-    SILKY_PYTHON_PROFILER = envvar("MREG_SILKY_PYTHON_PROFILER", True)
-    SILKY_PYTHON_PROFILER_BINARY = envvar("MREG_SILKY_PYTHON_PROFILER_BINARY", True)
-    SILKY_PYTHON_PROFILER_RESULT_PATH = envvar('MREG_SILKY_PYTHON_PROFILER_RESULT_PATH', 'silk/profiles')
-    SILKY_META = envvar("MREG_SILKY_META", False) # disable meta-profiling by default
+# Enable silk instrumentation of requests and queries
+MREG_PROFILING_ENABLED = envvar("MREG_PROFILING_ENABLED", False)
 
-    INSTALLED_APPS.append("silk")
-    MIDDLEWARE.insert(0, "silk.middleware.SilkyMiddleware")
+# Use cProfile for profiling of the selected views.
+# If this is disabled, silk will only collect request/response data and timings, 
+# but not detailed profiling information.
+SILKY_PYTHON_PROFILER = envvar("MREG_SILKY_PYTHON_PROFILER", True)
+
+# Save profiler results to disk for later analysis in silk or with other tools.
+SILKY_PYTHON_PROFILER_BINARY = envvar("MREG_SILKY_PYTHON_PROFILER_BINARY", True)
+SILKY_PYTHON_PROFILER_RESULT_PATH = envvar('MREG_SILKY_PYTHON_PROFILER_RESULT_PATH', 'silk/profiles')
+
+# Meta-profiling of requests (show silk's performance impact)
+SILKY_META = envvar("MREG_SILKY_META", False) # disable meta-profiling by default
 
 # Import local settings that may override those in this file.
 try:
@@ -556,3 +490,103 @@ if "DATABASES" not in globals():
             },
         }
     }
+
+# Configure Silk profiling if enabled
+if MREG_PROFILING_ENABLED:
+    logger = structlog.get_logger(__name__)
+    if not _silk_installed:
+        logger.error(
+            "MREG_PROFILING_ENABLED is set to True, but silk is not installed.",
+            "Install silk with `uv sync --(only-)group profile` or disable profiling.",
+        )
+        sys.exit(1)
+    
+    # NOTE: logging happens twice here on startup for some reason...
+    logger.warning("Profiling is enabled. All requests will be profiled with Silk. This will impact performance.")
+    
+    # Define views to enable Silk profiling for
+    # (Can be overridden by setting SILKY_DYNAMIC_PROFILING in local_settings.py)
+    if "SILKY_DYNAMIC_PROFILING" not in globals():
+        SILKY_DYNAMIC_PROFILING = [
+            {
+                "module": "mreg.api.v1.views",
+                "function": "HostDetail.get",
+                'name': 'Get single host',
+            },
+            {
+                "module": "mreg.api.v1.views",
+                "function": "HostList.get",
+                'name': 'Get hosts',
+            },
+            {
+                "module": "mreg.api.v1.views",
+                "function": "HostList.post",
+                'name': 'Create host',
+            },
+            {
+                "module": "hostpolicy.api.v1.views",
+                "function": "HostPolicyAtomDetail.get",
+                'name': 'Get single Atom',
+            },
+            {
+                "module": "hostpolicy.api.v1.views",
+                "function": "HostPolicyAtomDetail.delete",
+                'name': 'Delete single Atom',
+            },
+            {
+                "module": "hostpolicy.api.v1.views",
+                "function": "HostPolicyAtomList.get",
+                'name': 'Get Atoms',
+            },
+            {
+                "module": "hostpolicy.api.v1.views",
+                "function": "HostPolicyAtomList.post",
+                'name': 'Create Atom',
+            },
+            {
+                "module": "hostpolicy.api.v1.views",
+                "function": "HostPolicyRoleDetail.get",
+                'name': 'Get single Role',
+            },
+            {
+                "module": "hostpolicy.api.v1.views",
+                "function": "HostPolicyRoleDetail.delete",
+                'name': 'Delete a single Role',
+            },
+            {
+                "module": "hostpolicy.api.v1.views",
+                "function": "HostPolicyRoleList.get",
+                'name': 'Get Roles',
+            },
+            {
+                "module": "hostpolicy.api.v1.views",
+                "function": "HostPolicyRoleList.post",
+                'name': 'Create Role',
+            },
+            {
+                "module": "hostpolicy.api.v1.views",
+                "function": "HostPolicyRoleAtomsList.get",
+                'name': 'Get Role Atoms',
+            },
+            {
+                "module": "hostpolicy.api.v1.views",
+                "function": "HostPolicyRoleHostsList.get",
+                'name': 'Get Role Hosts',
+            },
+        ]
+    
+    # Ensure the profiler result path exists and is writable before enabling Silk
+    if SILKY_PYTHON_PROFILER_RESULT_PATH:
+        p = Path(SILKY_PYTHON_PROFILER_RESULT_PATH)
+        if not p.exists():
+            try:
+                p.mkdir(parents=True)
+            except OSError as e:
+                print(f"Failed to create Silk profiler result directory {SILKY_PYTHON_PROFILER_RESULT_PATH}: {e}", file=sys.stderr)
+                sys.exit(1)
+        elif not p.is_dir() or not os.access(p, os.W_OK):
+            print(f"Silk profiler result path {SILKY_PYTHON_PROFILER_RESULT_PATH} is not a writable directory.", file=sys.stderr)
+            sys.exit(1)
+
+    INSTALLED_APPS.append("silk")
+    MIDDLEWARE.insert(0, "silk.middleware.SilkyMiddleware")

--- a/mregsite/settings.py
+++ b/mregsite/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/2.0/ref/settings/
 
 import logging.config
 import os
+from pathlib import Path
 import sys
 from typing import Literal, TypeVar
 
@@ -417,6 +418,94 @@ structlog.configure(
     wrapper_class=structlog.stdlib.BoundLogger,
     cache_logger_on_first_use=True,
 )
+
+# Django Silk profiling settings
+try:
+    import silk  # noqa: F401  # pyright: ignore[reportUnusedImport, reportMissingTypeStubs]
+    _silk_installed = True
+except ImportError:
+    _silk_installed = False
+
+if MREG_PROFILING_ENABLED := envvar("MREG_PROFILING_ENABLED", False):
+    if not _silk_installed:
+        print("MREG_PROFILING_ENABLED is set to True, but silk is not installed. Please install silk or disable profiling.")
+        sys.exit(1)
+    print("Profiling is enabled. All requests will be profiled with Silk. This may have a performance impact.")
+    SILKY_DYNAMIC_PROFILING = [
+        {
+            "module": "mreg.api.v1.views",
+            "function": "HostDetail.get",
+            'name': 'Get single host',
+        },
+        {
+            "module": "mreg.api.v1.views",
+            "function": "HostList.get",
+            'name': 'Get hosts',
+        },
+        {
+            "module": "mreg.api.v1.views",
+            "function": "HostList.post",
+            'name': 'Create host',
+        },
+        {
+            "module": "hostpolicy.api.v1.views",
+            "function": "HostPolicyAtomDetail.get",
+            'name': 'Get single Atom',
+        },
+        {
+            "module": "hostpolicy.api.v1.views",
+            "function": "HostPolicyAtomDetail.delete",
+            'name': 'Delete single Atom',
+        },
+        {
+            "module": "hostpolicy.api.v1.views",
+            "function": "HostPolicyAtomList.get",
+            'name': 'Get Atoms',
+        },
+        {
+            "module": "hostpolicy.api.v1.views",
+            "function": "HostPolicyAtomList.post",
+            'name': 'Create Atom',
+        },
+        {
+            "module": "hostpolicy.api.v1.views",
+            "function": "HostPolicyRoleDetail.get",
+            'name': 'Get single Role',
+        },
+        {
+            "module": "hostpolicy.api.v1.views",
+            "function": "HostPolicyRoleDetail.delete",
+            'name': 'Delete a single Role',
+        },
+        {
+            "module": "hostpolicy.api.v1.views",
+            "function": "HostPolicyRoleList.get",
+            'name': 'Get Roles',
+        },
+        {
+            "module": "hostpolicy.api.v1.views",
+            "function": "HostPolicyRoleList.post",
+            'name': 'Create Role',
+        },
+        {
+            "module": "hostpolicy.api.v1.views",
+            "function": "HostPolicyRoleAtomsList.get",
+            'name': 'Get Role Atoms',
+        },
+        {
+            "module": "hostpolicy.api.v1.views",
+            "function": "HostPolicyRoleHostsList.get",
+            'name': 'Get Role Hosts',
+        },
+    ]
+    
+    SILKY_PYTHON_PROFILER = envvar("MREG_SILKY_PYTHON_PROFILER", True)
+    SILKY_PYTHON_PROFILER_BINARY = envvar("MREG_SILKY_PYTHON_PROFILER_BINARY", True)
+    SILKY_PYTHON_PROFILER_RESULT_PATH = envvar('MREG_SILKY_PYTHON_PROFILER_RESULT_PATH', 'silk/profiles')
+    SILKY_META = envvar("MREG_SILKY_META", False) # disable meta-profiling by default
+
+    INSTALLED_APPS.append("silk")
+    MIDDLEWARE.insert(0, "silk.middleware.SilkyMiddleware")
 
 # Import local settings that may override those in this file.
 try:

--- a/mregsite/urls.py
+++ b/mregsite/urls.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from django.urls import include, path
+from django.conf import settings
 
 from rest_framework.schemas import get_schema_view
 
@@ -13,3 +14,6 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('docs/', schema_view),
 ]
+
+if settings.MREG_PROFILING_ENABLED:
+    urlpatterns.append(path('silk/', include('silk.urls', namespace='silk')))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dev = [
     "pytest",
     "pytest-django",
     "uv>=0.9",
+    {include-group = "profile"},
 ]
 ci = [
     # Explictly include dev group for non-uv package managers
@@ -46,6 +47,8 @@ ci = [
     "tox-gh-actions", 
     "coveralls",
 ]
+profile = ["django-silk[formatting]>=5.5.0"]
+
 
 [tool.ruff]
 line-length = 140

--- a/uv.lock
+++ b/uv.lock
@@ -34,6 +34,19 @@ wheels = [
 ]
 
 [[package]]
+name = "autopep8"
+version = "2.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycodestyle" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/d8/30873d2b7b57dee9263e53d142da044c4600a46f2d28374b3e38b023df16/autopep8-2.3.2.tar.gz", hash = "sha256:89440a4f969197b69a995e4ce0661b031f455a9f776d2c5ba3dbd83466931758", size = 92210, upload-time = "2025-01-14T14:46:18.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/43/53afb8ba17218f19b77c7834128566c5bbb100a0ad9ba2e8e89d089d7079/autopep8-2.3.2-py2.py3-none-any.whl", hash = "sha256:ce8ad498672c845a0c3de2629c15b635ec2b05ef8177a6e7c91c74f3e9b51128", size = 45807, upload-time = "2025-01-14T14:46:15.466Z" },
+]
+
+[[package]]
 name = "cachetools"
 version = "6.2.4"
 source = { registry = "https://pypi.org/simple" }
@@ -315,6 +328,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/16/08/034a97f1f9bff7a5e8ae3180d7a33cba4154a75e444d167366aee78ea61a/django-netfields-1.3.2.tar.gz", hash = "sha256:e54943601bb88573b70f8843e7080f5d7327e41f5500ce30a198c384cc325a60", size = 36764, upload-time = "2023-12-13T17:41:36.256Z" }
 
 [[package]]
+name = "django-silk"
+version = "5.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django", version = "5.2.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "django", version = "6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "gprof2dot" },
+    { name = "sqlparse" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/3e/db3bda7cf1327aa3800d32dca80f0d077954b52f61dc32cf76f605a28767/django_silk-5.5.0.tar.gz", hash = "sha256:41fcabe65d59d31ccdb69daeb3c3e6d30879ab2c00b0875b111fda0f69aec065", size = 4495794, upload-time = "2026-03-08T05:00:57.663Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/54/c56950e8b9279d2c6156d46571a64c1a808c07bddde571819e2bdbb8d5e3/django_silk-5.5.0-py3-none-any.whl", hash = "sha256:82b5a690d623935be916dd145e2f605a4ac9454d54e03df6a7ffcf38333c8444", size = 1944887, upload-time = "2026-03-08T05:01:13.646Z" },
+]
+
+[package.optional-dependencies]
+formatting = [
+    { name = "autopep8" },
+]
+
+[[package]]
 name = "djangorestframework"
 version = "3.16.1"
 source = { registry = "https://pypi.org/simple" }
@@ -388,6 +421,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1d/65/ce7f1b70157833bf3cb851b556a37d4547ceafc158aa9b34b36782f23696/filelock-3.20.3.tar.gz", hash = "sha256:18c57ee915c7ec61cff0ecf7f0f869936c7c30191bb0cf406f1341778d0834e1", size = 19485, upload-time = "2026-01-09T17:55:05.421Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl", hash = "sha256:4b0dda527ee31078689fc205ec4f1c1bf7d56cf88b6dc9426c4f230e46c2dce1", size = 16701, upload-time = "2026-01-09T17:55:04.334Z" },
+]
+
+[[package]]
+name = "gprof2dot"
+version = "2025.4.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/fd/cad13fa1f7a463a607176432c4affa33ea162f02f58cc36de1d40d3e6b48/gprof2dot-2025.4.14.tar.gz", hash = "sha256:35743e2d2ca027bf48fa7cba37021aaf4a27beeae1ae8e05a50b55f1f921a6ce", size = 39536, upload-time = "2025-04-14T07:21:45.76Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/ed/89d760cb25279109b89eb52975a7b5479700d3114a2421ce735bfb2e7513/gprof2dot-2025.4.14-py3-none-any.whl", hash = "sha256:0742e4c0b4409a5e8777e739388a11e1ed3750be86895655312ea7c20bd0090e", size = 37555, upload-time = "2025-04-14T07:21:43.319Z" },
 ]
 
 [[package]]
@@ -484,6 +526,9 @@ dev = [
     { name = "tox-uv" },
     { name = "uv" },
 ]
+profile = [
+    { name = "django-silk", extra = ["formatting"] },
+]
 
 [package.metadata]
 requires-dist = [
@@ -525,6 +570,7 @@ dev = [
     { name = "tox-uv", specifier = ">=1.29" },
     { name = "uv", specifier = ">=0.9" },
 ]
+profile = [{ name = "django-silk", extras = ["formatting"], specifier = ">=5.5.0" }]
 
 [[package]]
 name = "netaddr"
@@ -694,6 +740,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1d/67/6afbf0d507f73c32d21084a79946bfcfca5fbc62a72057e9c23797a737c9/pyasn1_modules-0.4.1.tar.gz", hash = "sha256:c28e2dbf9c06ad61c71a075c7e0f9fd0f1b0bb2d2ad4377f240d33ac2ab60a7c", size = 310028, upload-time = "2024-09-10T22:42:08.349Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/77/89/bc88a6711935ba795a679ea6ebee07e128050d6382eaa35a0a47c8032bdc/pyasn1_modules-0.4.1-py3-none-any.whl", hash = "sha256:49bfa96b45a292b711e986f222502c1c9a5e1f4e568fc30e2574a6c7d07838fd", size = 181537, upload-time = "2024-09-11T16:02:10.336Z" },
+]
+
+[[package]]
+name = "pycodestyle"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/e0/abfd2a0d2efe47670df87f3e3a0e2edda42f055053c85361f19c0e2c1ca8/pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783", size = 39472, upload-time = "2025-06-20T18:49:48.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/27/a58ddaf8c588a3ef080db9d0b7e0b97215cee3a45df74f3a94dbbf5c893a/pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d", size = 31594, upload-time = "2025-06-20T18:49:47.491Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -513,6 +513,7 @@ dependencies = [
 ci = [
     { name = "coverage", extra = ["toml"] },
     { name = "coveralls" },
+    { name = "django-silk", extra = ["formatting"] },
     { name = "pytest" },
     { name = "pytest-django" },
     { name = "tox-gh-actions" },
@@ -521,6 +522,7 @@ ci = [
 ]
 dev = [
     { name = "coverage", extra = ["toml"] },
+    { name = "django-silk", extra = ["formatting"] },
     { name = "pytest" },
     { name = "pytest-django" },
     { name = "tox-uv" },
@@ -557,6 +559,7 @@ requires-dist = [
 ci = [
     { name = "coverage", extras = ["toml"] },
     { name = "coveralls" },
+    { name = "django-silk", extras = ["formatting"], specifier = ">=5.5.0" },
     { name = "pytest" },
     { name = "pytest-django" },
     { name = "tox-gh-actions" },
@@ -565,6 +568,7 @@ ci = [
 ]
 dev = [
     { name = "coverage", extras = ["toml"] },
+    { name = "django-silk", extras = ["formatting"], specifier = ">=5.5.0" },
     { name = "pytest" },
     { name = "pytest-django" },
     { name = "tox-uv", specifier = ">=1.29" },


### PR DESCRIPTION
This PR adds the ability to profile requests and queries via [django-silk](https://github.com/jazzband/django-silk). 

## New config options

| Variable | Default | Description |
| -------- | ------- | ----------- |
| `MREG_PROFILING_ENABLED` | `False` | Enable Silk request/query instrumentation |
| `MREG_SILKY_PYTHON_PROFILER` | `True` | Use cProfile for detailed per-request profiling (requires `MREG_PROFILING_ENABLED`) |
| `MREG_SILKY_PYTHON_PROFILER_BINARY` | `True` | Save cProfile results to disk as `.prof` files for offline analysis |
| `MREG_SILKY_PYTHON_PROFILER_RESULT_PATH` | `silk/profiles` | Directory to write `.prof` files into |
| `MREG_SILKY_META` | `False` | Enable Silk meta-profiling (measures Silk's own overhead) |

## Instrumented endpoints

Only a subset of endpoints have been instrumented with silk, configured via `SILKY_DYNAMIC_PROFILING` in `mregsite/settings.py`. 

They are:

| Name | Module | View.method |
|------|--------|-------------|
| Get single host | `mreg.api.v1.views` | `HostDetail.get` |
| Get hosts | `mreg.api.v1.views` | `HostList.get` |
| Create host | `mreg.api.v1.views` | `HostList.post` |
| Get single Atom | `hostpolicy.api.v1.views` | `HostPolicyAtomDetail.get` |
| Delete single Atom | `hostpolicy.api.v1.views` | `HostPolicyAtomDetail.delete` |
| Get Atoms | `hostpolicy.api.v1.views` | `HostPolicyAtomList.get` |
| Create Atom | `hostpolicy.api.v1.views` | `HostPolicyAtomList.post` |
| Get single Role | `hostpolicy.api.v1.views` | `HostPolicyRoleDetail.get` |
| Delete a single Role | `hostpolicy.api.v1.views` | `HostPolicyRoleDetail.delete` |
| Get Roles | `hostpolicy.api.v1.views` | `HostPolicyRoleList.get` |
| Create Role | `hostpolicy.api.v1.views` | `HostPolicyRoleList.post` |
| Get Role Atoms | `hostpolicy.api.v1.views` | `HostPolicyRoleAtomsList.get` |
| Get Role Hosts | `hostpolicy.api.v1.views` | `HostPolicyRoleHostsList.get` |


For one-off changes during local profiling that does not need to be commited upstream, `SILKY_DYNAMIC_PROFILING` may be overridden in `local_settings.py` to define other endpoints to instrument.

We may want to expand the default endpoints to instrument with profiling in the future. 

## Dependency group

A new dependency group `profile` has been added if we want to create silk-instrumented container images in the future.
For now, the Dockerfile remains unchanged, but in the future, we could do something like this in the dockerfile if certain flags are present to install django-silk in container images:

```
uv sync --only-group profile
```

