### PR TITLE
Add `network_cidr` field to community serializer

### DIFF
--- a/mreg/api/v1/serializers.py
+++ b/mreg/api/v1/serializers.py
@@ -35,9 +35,9 @@ class CommunitySerializer(serializers.ModelSerializer):
     # Members are all the hosts that have this community assigned.
     hosts = serializers.SerializerMethodField(read_only=True)
     global_name = serializers.SerializerMethodField(read_only=True)
-    network_address = serializers.SerializerMethodField(read_only=True)
+    network_cidr = serializers.SerializerMethodField(read_only=True)
 
-    def get_network_address(self, obj) -> str:
+    def get_network_cidr(self, obj) -> str:
         return str(obj.network.network)
 
     def get_hosts(self, obj):
@@ -81,7 +81,7 @@ class CommunitySerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Community
-        fields = ['id', 'name', 'description', 'network', 'network_address', 'hosts', 'global_name', 'created_at', 'updated_at']
+        fields = ['id', 'name', 'description', 'network', 'network_cidr', 'hosts', 'global_name', 'created_at', 'updated_at']
         read_only_fields = ['network'] 
 
 

--- a/mreg/api/v1/serializers.py
+++ b/mreg/api/v1/serializers.py
@@ -35,6 +35,10 @@ class CommunitySerializer(serializers.ModelSerializer):
     # Members are all the hosts that have this community assigned.
     hosts = serializers.SerializerMethodField(read_only=True)
     global_name = serializers.SerializerMethodField(read_only=True)
+    network_address = serializers.SerializerMethodField(read_only=True)
+
+    def get_network_address(self, obj) -> str:
+        return str(obj.network.network)
 
     def get_hosts(self, obj):
         return list(obj.hosts.values_list("name", flat=True))
@@ -77,7 +81,7 @@ class CommunitySerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Community
-        fields = ['id', 'name', 'description', 'network', 'hosts', 'global_name', 'created_at', 'updated_at']
+        fields = ['id', 'name', 'description', 'network', 'network_address', 'hosts', 'global_name', 'created_at', 'updated_at']
         read_only_fields = ['network'] 
 
 

--- a/mreg/api/v1/tests/test_network_policy.py
+++ b/mreg/api/v1/tests/test_network_policy.py
@@ -311,6 +311,15 @@ class NetworkPolicyTestCase(ParametrizedTestCase, MregAPITestCase):
         network.delete()
         self.assertFalse(Community.objects.filter(pk=community_id).exists())  # Cascade delete
 
+    def test_community_serializer_includes_network_address(self):
+        """Community response includes network_address matching the bound network's CIDR."""
+        network = Network.objects.create(network="10.0.0.0/24", description="test_network")
+        ret = self.assert_post_and_201(f"networks/{network.network}/communities/", data={"name": "comm1", "description": ""})
+        community_id = ret.json()["id"]
+
+        get_res = self.assert_get(f"networks/{network.network}/communities/{community_id}")
+        self.assertEqual(get_res.json()["network_address"], "10.0.0.0/24")
+
     def create_community_no_name_400(self):
         """Test creating a community without a name."""
         network = Network.objects.create(network="10.0.0.0/24", description="test_network")

--- a/mreg/api/v1/tests/test_network_policy.py
+++ b/mreg/api/v1/tests/test_network_policy.py
@@ -311,14 +311,14 @@ class NetworkPolicyTestCase(ParametrizedTestCase, MregAPITestCase):
         network.delete()
         self.assertFalse(Community.objects.filter(pk=community_id).exists())  # Cascade delete
 
-    def test_community_serializer_includes_network_address(self):
-        """Community response includes network_address matching the bound network's CIDR."""
+    def test_community_serializer_includes_cidr(self):
+        """Community response includes cidr matching the bound network's CIDR."""
         network = Network.objects.create(network="10.0.0.0/24", description="test_network")
         ret = self.assert_post_and_201(f"networks/{network.network}/communities/", data={"name": "comm1", "description": ""})
         community_id = ret.json()["id"]
 
         get_res = self.assert_get(f"networks/{network.network}/communities/{community_id}")
-        self.assertEqual(get_res.json()["network_address"], "10.0.0.0/24")
+        self.assertEqual(get_res.json()["network_cidr"], "10.0.0.0/24")
 
     def create_community_no_name_400(self):
         """Test creating a community without a name."""


### PR DESCRIPTION
This PR adds a new `network_cidr` field to serialized communities, which is the network CIDR of the network it is bound to. Improves API ergonomics.

## Rationale

In order to contact a community's endpoint, we are reliant on the network CIDR the community is bound to, i.e.

```
/networks/10.0.0.0/24/communities/1
          ^^^^^^^^^^^
```

But what we receive from the API for a Community object currently is something like this:

```jsonc
{
  "name": "mycommunity",
  "id": 1,
  "network": 123,
  // ...
}
```

Thus, consumers cannot construct the URL for the community based on just that object.

## New field: `network_cidr`

By adding the network CIDR to the serialized community, we can now construct the URL based exclusively on the community data without having to perform extra lookups or stitching together data from multiple objects:

```jsonc
{
  "name": "mycommunity",
  "id": 1,
  "network": 123,
  "network_cidr": "10.0.0.1/24",
  // ...
}
```

## Improves mreg-api ergonomics

Interacting with communities is awkward in mreg-api currently, because we need to manually fetch the network first, and pass that to every method that interacts with communities:

```py
# Fetch network, use network to fetch community
net = client.network.get("10.0.0.0/24")
com = client.network.community.get("mycom", net) 

client.network.community.update(com, net, description="My new description")
client.network.community.add_host(com, net, some_host_obj)
client.network.community.delete(com, net)
```

With this PR, the network CIDR is bound to the community object, and we can thus fetch the network as part of the community fetch operation (and , and we don't need pass around the network object:

```py
# No need to pass around network, can be fetched implicitly and discarded after fetching community
com = client.network.community.get("mycom", "10.0.0.0/24") 

client.network.community.update(com, description="My new description")
client.network.community.add_host(com, some_host_obj)
client.network.community.delete(com)
```

