### PR TITLE
Accept `primary_ns` & `nameservers` as strings in zone endpoints

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -152,8 +152,12 @@ jobs:
 
   publish:
     name: Publish
-    # Run for version tags, commits to master branch, and pull requests
-    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master' || github.event_name == 'pull_request'
+    # Fork pull requests cannot write organization packages with GITHUB_TOKEN.
+    # Publish only version tags, master commits, and same-repository pull requests.
+    if: >-
+      startsWith(github.ref, 'refs/tags/v') ||
+      github.ref == 'refs/heads/master' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     needs: [test, test-with-curl]
     runs-on: ubuntu-latest
     permissions:

--- a/mreg/api/v1/tests/tests_zones.py
+++ b/mreg/api/v1/tests/tests_zones.py
@@ -29,6 +29,9 @@ class ForwardZonesTestCase(MregAPITestCase):
         self.post_data_two = {'name': 'example.net',
                               'primary_ns': ['ns1.example.org', 'ns2.example.org'],
                               'email': "hostmaster@example.org"}
+        self.post_data_three = {'name': 'example.co.uk',
+                              'primary_ns': 'ns3.example.org',
+                              'email': "hostmaster@example.org"}
         self.patch_data = {'refresh': '500', 'expire': '1000'}
         clean_and_save(self.host_one)
         clean_and_save(self.host_two)
@@ -60,6 +63,11 @@ class ForwardZonesTestCase(MregAPITestCase):
         """"Posting a new zone should return 201 and location"""
         response = self.assert_post('/zones/forward/', self.post_data_one)
         self.assertEqual(response['Location'], '/api/v1/zones/forward/%s' % self.post_data_one['name'])
+    
+    def test_zones_post_201_primary_ns_str(self):
+        """"Posting a new zone with primary_ns as a string should return 201 and location"""
+        response = self.assert_post('/zones/forward/', self.post_data_three)
+        self.assertEqual(response['Location'], '/api/v1/zones/forward/%s' % self.post_data_three['name'])
 
     def test_zones_post_serialno(self):
         """serialno should be based on the current date and a sequential number"""
@@ -157,6 +165,9 @@ class ReverseZonesTestCase(MregAPITestCase):
         self.post_data_two = {'name': '0.16.172.in-addr.arpa',
                               'primary_ns': ['ns1.example.org', 'ns2.example.org'],
                               'email': "hostmaster@example.org"}
+        self.post_data_three = {'name': '0.168.192.in-addr.arpa',
+                              'primary_ns': 'ns3.example.org', # primary_ns is a str
+                              'email': "hostmaster@example.org"}
         self.patch_data = {'refresh': '500', 'expire': '1000'}
         clean_and_save(self.host_one)
         clean_and_save(self.host_two)
@@ -188,6 +199,11 @@ class ReverseZonesTestCase(MregAPITestCase):
         """"Posting a new zone should return 201 and location"""
         response = self.assert_post(self.basepath, self.post_data_one)
         self.assertEqual(response['Location'], '/api/v1/zones/reverse/%s' % self.post_data_one['name'])
+
+    def test_zones_post_201_primary_ns_str(self):
+        """"Posting a new zone with primary_ns as a string should return 201 and location"""
+        response = self.assert_post(self.basepath, self.post_data_three)
+        self.assertEqual(response['Location'], '/api/v1/zones/reverse/%s' % self.post_data_three['name'])
 
     def test_zones_post_serialno(self):
         """serialno should be based on the current date and a sequential number"""
@@ -264,6 +280,15 @@ class ZonesForwardDelegationTestCase(MregAPITestCase):
         path = self.del_path('example.org')
         data = {'name': 'delegated.example.org',
                 'nameservers': ['ns1.example.org', 'ns1.delegated.example.org'],
+                'comment': 'delegated to Mr. Anderson'}
+        response = self.assert_post(path, data)
+        self.assertEqual(response['Location'], f"{path}delegated.example.org")
+    
+    def test_delegate_forward_nameservers_str_201_ok(self):
+        """Posting a new delegation with nameservers as a string should return 201 and location"""
+        path = self.del_path('example.org')
+        data = {'name': 'delegated.example.org',
+                'nameservers': 'ns1.example.org',
                 'comment': 'delegated to Mr. Anderson'}
         response = self.assert_post(path, data)
         self.assertEqual(response['Location'], f"{path}delegated.example.org")
@@ -444,6 +469,21 @@ class ZonesReverseDelegationTestCase(MregAPITestCase):
         response = self.assert_post(path, self.del_10101010)
         self.assertEqual(response['Location'], f"{path}10.10.10.10.in-addr.arpa")
         self.assert_get(response['Location'])
+    
+    def test_delegate_ipv4_nameservers_str_201_ok(self):
+        path = self.del_path('10.10.in-addr.arpa')
+
+        data = self.del_101010.copy()
+        data['nameservers'] = 'ns1.example.org'
+        response = self.assert_post(path, data)
+        self.assertEqual(response['Location'], f"{path}10.10.10.in-addr.arpa")
+        self.assert_get(response['Location'])
+
+        data = self.del_10101010.copy()
+        data['nameservers'] = 'ns1.example.org'
+        response = self.assert_post(path, data)
+        self.assertEqual(response['Location'], f"{path}10.10.10.10.in-addr.arpa")
+        self.assert_get(response['Location'])
 
     def test_delegate_ipv4_zonefiles_200_ok(self):
         self.test_delegate_ipv4_201_ok()
@@ -485,6 +525,15 @@ class ZonesReverseDelegationTestCase(MregAPITestCase):
         path = self.del_path('8.b.d.0.1.0.0.2.ip6.arpa')
         response = self.assert_post(path, self.del_2001db810)
         self.assertEqual(response['Location'], f"{path}{self.del_2001db810['name']}")
+        self.assert_get(response['Location'])
+    
+    def test_delegate_ipv6_nameservers_str_201_ok(self):
+        """Test IPv6 delegation with nameservers as a string."""
+        path = self.del_path('8.b.d.0.1.0.0.2.ip6.arpa')
+        data = self.del_2001db810.copy()
+        data['nameservers'] = 'ns1.example.org'
+        response = self.assert_post(path, data)
+        self.assertEqual(response['Location'], f"{path}{data['name']}")
         self.assert_get(response['Location'])
 
     def test_delegate_ipv6_zonefiles_200_ok(self):

--- a/mreg/api/v1/tests/tests_zones.py
+++ b/mreg/api/v1/tests/tests_zones.py
@@ -29,9 +29,11 @@ class ForwardZonesTestCase(MregAPITestCase):
         self.post_data_two = {'name': 'example.net',
                               'primary_ns': ['ns1.example.org', 'ns2.example.org'],
                               'email': "hostmaster@example.org"}
-        self.post_data_three = {'name': 'example.co.uk',
-                              'primary_ns': 'ns3.example.org',
-                              'email': "hostmaster@example.org"}
+        self.post_data_three = {
+            'name': 'example.co.uk',
+            'primary_ns': 'ns3.example.org',
+            'email': "hostmaster@example.org",
+        }
         self.patch_data = {'refresh': '500', 'expire': '1000'}
         clean_and_save(self.host_one)
         clean_and_save(self.host_two)
@@ -63,7 +65,7 @@ class ForwardZonesTestCase(MregAPITestCase):
         """"Posting a new zone should return 201 and location"""
         response = self.assert_post('/zones/forward/', self.post_data_one)
         self.assertEqual(response['Location'], '/api/v1/zones/forward/%s' % self.post_data_one['name'])
-    
+
     def test_zones_post_201_primary_ns_str(self):
         """"Posting a new zone with primary_ns as a string should return 201 and location"""
         response = self.assert_post('/zones/forward/', self.post_data_three)
@@ -165,9 +167,11 @@ class ReverseZonesTestCase(MregAPITestCase):
         self.post_data_two = {'name': '0.16.172.in-addr.arpa',
                               'primary_ns': ['ns1.example.org', 'ns2.example.org'],
                               'email': "hostmaster@example.org"}
-        self.post_data_three = {'name': '0.168.192.in-addr.arpa',
-                              'primary_ns': 'ns3.example.org', # primary_ns is a str
-                              'email': "hostmaster@example.org"}
+        self.post_data_three = {
+            'name': '0.168.192.in-addr.arpa',
+            'primary_ns': 'ns3.example.org',
+            'email': "hostmaster@example.org",
+        }
         self.patch_data = {'refresh': '500', 'expire': '1000'}
         clean_and_save(self.host_one)
         clean_and_save(self.host_two)
@@ -283,7 +287,7 @@ class ZonesForwardDelegationTestCase(MregAPITestCase):
                 'comment': 'delegated to Mr. Anderson'}
         response = self.assert_post(path, data)
         self.assertEqual(response['Location'], f"{path}delegated.example.org")
-    
+
     def test_delegate_forward_nameservers_str_201_ok(self):
         """Posting a new delegation with nameservers as a string should return 201 and location"""
         path = self.del_path('example.org')
@@ -469,7 +473,7 @@ class ZonesReverseDelegationTestCase(MregAPITestCase):
         response = self.assert_post(path, self.del_10101010)
         self.assertEqual(response['Location'], f"{path}10.10.10.10.in-addr.arpa")
         self.assert_get(response['Location'])
-    
+
     def test_delegate_ipv4_nameservers_str_201_ok(self):
         path = self.del_path('10.10.in-addr.arpa')
 
@@ -526,7 +530,7 @@ class ZonesReverseDelegationTestCase(MregAPITestCase):
         response = self.assert_post(path, self.del_2001db810)
         self.assertEqual(response['Location'], f"{path}{self.del_2001db810['name']}")
         self.assert_get(response['Location'])
-    
+
     def test_delegate_ipv6_nameservers_str_201_ok(self):
         """Test IPv6 delegation with nameservers as a string."""
         path = self.del_path('8.b.d.0.1.0.0.2.ip6.arpa')

--- a/mreg/api/v1/views_zones.py
+++ b/mreg/api/v1/views_zones.py
@@ -60,8 +60,12 @@ def _validate_nameservers(names):
 def _get_request_nameservers(request: Request, field: str = "primary_ns") -> List[str]:
     """Extract nameservers from the request data."""
     if request.content_type == "application/json":
-        return request.data.get(field, [])
-    return request.data.getlist(field, [])
+        nameservers = request.data.get(field, [])
+    else:
+        nameservers = request.data.getlist(field, [])
+    if isinstance(nameservers, str):
+        nameservers = [nameservers]
+    return nameservers
 
 
 class ZoneList(generics.ListCreateAPIView):

--- a/mreg/api/v1/views_zones.py
+++ b/mreg/api/v1/views_zones.py
@@ -58,7 +58,7 @@ def _validate_nameservers(names):
 
 
 def _get_request_nameservers(request: Request, field: str = "primary_ns") -> List[str]:
-    """Extract nameservers from the request data."""
+    """Extract nameservers as a list, accepting a JSON string or array."""
     if request.content_type == "application/json":
         nameservers = request.data.get(field, [])
     else:
@@ -74,7 +74,8 @@ class ZoneList(generics.ListCreateAPIView):
     Returns a list of all zones.
 
     post:
-    Create a zone. The primary_ns field is a list where the first element will be the primary nameserver.
+    Create a zone. The primary_ns field accepts a nameserver string or a list;
+    the first list element becomes the primary nameserver.
 
     """
 
@@ -123,7 +124,8 @@ class ZoneDelegationList(generics.ListCreateAPIView):
     Returns a list of all the zone's delegations.
 
     post:
-    Create a delegation for the zone.
+    Create a delegation for the zone. The nameservers field accepts a
+    nameserver string or a list.
     """
 
     lookup_field = 'name'
@@ -294,7 +296,8 @@ class ZoneNameServerDetail(MregRetrieveUpdateDestroyAPIView):
 
     patch:
     Set the nameserver list of a zone. Requires all the nameservers of the zone
-    and removes the ones not mentioned.
+    and removes the ones not mentioned. The primary_ns field accepts a
+    nameserver string or a list.
     """
 
     lookup_field = 'name'


### PR DESCRIPTION
This PR adds support for passing `primary_ns` as a string to zone endpoints by adding rudimentary type checking to `_get_request_nameservers()` to coerce string values to lists.

----

These endpoints pick the first item in the list passed to them, discarding any nameservers beyond the first one, so it makes sense to be able to pass this value as a string. Furthermore, this change makes the POST payload more consistent with the serialized representation of zones, which already serialize `primary_ns` as a string. 

