### PR TITLE
Add portable snapshot endpoint

### DIFF
--- a/docs/snapshot.md
+++ b/docs/snapshot.md
@@ -38,13 +38,12 @@ consumers can translate or inspect the legacy authorization model explicitly.
 {"ref":"netgroup_regex_permission:17","kind":"netgroup_regex_permission","operation":"create","attributes":{"group":"dns-admins","range":"192.0.2.0/24","regex":".*\\.example\\.org","labels":["production"]}}
 ```
 
-For compatibility with the current import endpoint, request
-`format=mreg-import-json-v1` with `Accept: application/json`. This returns a
-gzip-compressed document containing `{ "requested_by": ..., "items": [...],
-"deferred_records": [...] }`. The import endpoint consumes `items`;
-consumers must inspect `deferred_records` separately.
-`include_permissions=true` is not supported for this compatibility
-representation.
+To produce a single JSON import file rather than a tar archive, request
+`format=mreg-import-json-v1` with `Accept: application/json`. The response is a
+gzip-compressed JSON document containing `{ "requested_by": ..., "items": [...],
+"deferred_records": [...] }`. The `items` array contains the dependency-ordered
+import payload; consumers must inspect `deferred_records` separately.
+`include_permissions=true` is not supported for this JSON representation.
 
 Version 1 only accepts these option values:
 

--- a/docs/snapshot.md
+++ b/docs/snapshot.md
@@ -4,9 +4,8 @@
 snapshot for backup, transfer, and recovery workflows. The endpoint is
 synchronous and intended for rare, operator-driven work.
 
-The caller must authenticate with an MREG token and belong to the group named
-by `MREG_SNAPSHOT_GROUP`. MREG administrators and superusers do not get
-this permission implicitly.
+The caller must authenticate with an MREG token and either belong to the group
+named by `MREG_SNAPSHOT_GROUP` or be an MREG administrator or superuser.
 
 ## Archive format
 

--- a/docs/snapshot.md
+++ b/docs/snapshot.md
@@ -1,0 +1,70 @@
+# Portable snapshots
+
+`GET /api/v1/snapshot` creates a consistent, implementation-independent
+snapshot for backup, transfer, and recovery workflows. The endpoint is
+synchronous and intended for rare, operator-driven work.
+
+The caller must authenticate with an MREG token and belong to the group named
+by `MREG_SNAPSHOT_GROUP`. MREG administrators and superusers do not get
+this permission implicitly.
+
+## Archive format
+
+```text
+GET /api/v1/snapshot?format=mreg-snapshot-v1
+Accept: application/vnd.uio.mreg-snapshot+tar
+Accept-Encoding: gzip
+```
+
+The response is a gzip-compressed tar archive containing `manifest.json` and
+`items.ndjson`. Each NDJSON line is a dependency-ordered snapshot item. The
+manifest records the source, consistent database timestamp, item count, and
+checksum.
+
+Set `include_permissions=true` to add a separately checksummed
+`permissions.ndjson` member. It contains the legacy netgroup-regex authorization
+rules, including their group, CIDR range, hostname regular expression, and label
+names. Permission records are kept separate from portable domain items so
+consumers can translate or inspect the legacy authorization model explicitly.
+
+```json
+{"ref":"netgroup_regex_permission:17","kind":"netgroup_regex_permission","operation":"create","attributes":{"group":"dns-admins","range":"192.0.2.0/24","regex":".*\\.example\\.org","labels":["production"]}}
+```
+
+For compatibility with the current import endpoint, request
+`format=mreg-import-json-v1` with `Accept: application/json`. This returns the
+same items as a gzip-compressed `{ "requested_by": ..., "items": [...] }`
+document. `include_permissions=true` is not supported for this compatibility
+representation.
+
+Version 1 only accepts these option values:
+
+| Option | Supported value |
+| --- | --- |
+| `include_audit` | `false` |
+| `include_permissions` | `false` or `true` for `mreg-snapshot-v1` |
+| `validate` | `true` |
+| `redact` | `false` |
+
+Users, tokens, history, and Django authorization group membership are not
+included. Legacy netgroup-regex permission rules are optional. Host and network
+policy domain objects are always included. Generated A, AAAA, PTR, and zone NS
+records are omitted because the restored MREG state derives them from
+structural objects. Wildcard host DNS data is converted to explicit record
+items.
+
+## Operation
+
+The snapshot generator reads through one PostgreSQL repeatable-read, read-only
+transaction. It writes the translated items and completed artifact to the
+directory selected by `MREG_SNAPSHOT_TMPDIR`, or the operating-system
+temporary directory when unset. Ensure this filesystem can hold both the
+uncompressed NDJSON and compressed response. `MREG_SNAPSHOT_CHUNK_SIZE`
+controls ORM iterator batches and defaults to 2000.
+
+The database transaction is closed before the artifact is downloaded. A client
+disconnect therefore does not leave a snapshot transaction open, and temporary
+files are removed when the response closes.
+
+This snapshot is a portable application-data contract rather than a forensic
+replica. Preserve a separate SQL dump until recovery has been validated.

--- a/docs/snapshot.md
+++ b/docs/snapshot.md
@@ -16,10 +16,17 @@ Accept: application/vnd.uio.mreg-snapshot+tar
 Accept-Encoding: gzip
 ```
 
-The response is a gzip-compressed tar archive containing `manifest.json` and
-`items.ndjson`. Each NDJSON line is a dependency-ordered snapshot item. The
-manifest records the source, consistent database timestamp, item count, and
-checksum.
+The response is a gzip-compressed tar archive containing `manifest.json`,
+`items.ndjson`, and `deferred-records.ndjson`. Each line in `items.ndjson`
+is a dependency-ordered import item. The manifest records the source,
+consistent database timestamp, item counts, and checksums.
+
+Wildcard HINFO, LOC, and SSHFP records are valid source data, but cannot be
+represented by the version 1 import contract because those record types require
+hostname owners. They are preserved, with their source references and data, in
+`deferred-records.ndjson`. Each entry includes a `deferred` reason and must be
+handled manually by a consumer. The manifest's
+`semantics.fully_importable` value is false when this file contains records.
 
 Set `include_permissions=true` to add a separately checksummed
 `permissions.ndjson` member. It contains the legacy netgroup-regex authorization
@@ -32,9 +39,11 @@ consumers can translate or inspect the legacy authorization model explicitly.
 ```
 
 For compatibility with the current import endpoint, request
-`format=mreg-import-json-v1` with `Accept: application/json`. This returns the
-same items as a gzip-compressed `{ "requested_by": ..., "items": [...] }`
-document. `include_permissions=true` is not supported for this compatibility
+`format=mreg-import-json-v1` with `Accept: application/json`. This returns a
+gzip-compressed document containing `{ "requested_by": ..., "items": [...],
+"deferred_records": [...] }`. The import endpoint consumes `items`;
+consumers must inspect `deferred_records` separately.
+`include_permissions=true` is not supported for this compatibility
 representation.
 
 Version 1 only accepts these option values:

--- a/mreg/api/permissions.py
+++ b/mreg/api/permissions.py
@@ -67,6 +67,15 @@ class IsSuperGroupMember(IsAuthenticated):
         return User.from_request(request).is_mreg_superuser
 
 
+class IsSnapshotGroupMember(IsAuthenticated):
+    """Allow portable snapshots to members of the dedicated group only."""
+
+    def has_permission(self, request, view):
+        if not super().has_permission(request, view):
+            return False
+        return User.from_request(request).is_mreg_snapshotter
+
+
 class IsSuperOrAdminOrReadOnly(IsAuthenticated):
     """
     Permit user if in super or admin group, else read only.
@@ -388,4 +397,3 @@ class IsGrantedReservedAddressPermission(IsAuthenticated):
         # in a `BaseModel` instance instead of a serializer when checking
         # destroy permissions, so we cannot access any sort of validated data.
         return self.has_permission(request, view)
-

--- a/mreg/api/permissions.py
+++ b/mreg/api/permissions.py
@@ -67,13 +67,14 @@ class IsSuperGroupMember(IsAuthenticated):
         return User.from_request(request).is_mreg_superuser
 
 
-class IsSnapshotGroupMember(IsAuthenticated):
-    """Allow portable snapshots to members of the dedicated group only."""
+class IsSnapshotterOrAdmin(IsAuthenticated):
+    """Allow portable snapshots to dedicated group members and MREG admins."""
 
     def has_permission(self, request, view):
         if not super().has_permission(request, view):
             return False
-        return User.from_request(request).is_mreg_snapshotter
+        user = User.from_request(request)
+        return user.is_mreg_snapshotter or user.is_mreg_superuser_or_admin
 
 
 class IsSuperOrAdminOrReadOnly(IsAuthenticated):

--- a/mreg/api/v1/snapshot.py
+++ b/mreg/api/v1/snapshot.py
@@ -26,7 +26,7 @@ from rest_framework.views import APIView
 
 from hostpolicy.models import HostPolicyAtom, HostPolicyRole
 from mreg import __version__
-from mreg.api.permissions import IsSnapshotGroupMember
+from mreg.api.permissions import IsSnapshotterOrAdmin
 from mreg.models.base import Label, NameServer
 from mreg.models.host import BACnetID, Host, HostContact, HostGroup, Ipaddress, PtrOverride
 from mreg.models.network import NetGroupRegexPermission, Network, NetworkExcludedRange
@@ -1014,7 +1014,7 @@ def _parse_request(request) -> SnapshotOptions:
 
 
 class SnapshotView(APIView):
-    permission_classes = (IsSnapshotGroupMember,)
+    permission_classes = (IsSnapshotterOrAdmin,)
     renderer_classes = (SnapshotArchiveRenderer, SnapshotJSONRenderer)
 
     def handle_exception(self, exc: Exception) -> Response:

--- a/mreg/api/v1/snapshot.py
+++ b/mreg/api/v1/snapshot.py
@@ -6,6 +6,7 @@ import base64
 import gzip
 import hashlib
 import ipaddress
+import io
 import json
 import tarfile
 import tempfile
@@ -18,16 +19,16 @@ from django.conf import settings
 from django.db import DatabaseError, connection, transaction
 from django.db.models import Count
 from django.http import FileResponse
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from hostpolicy.models import HostPolicyAtom, HostPolicyRole
 from mreg import __version__
-from mreg.api.permissions import IsAuthenticated
+from mreg.api.permissions import IsSnapshotGroupMember
 from mreg.models.base import Label, NameServer
 from mreg.models.host import BACnetID, Host, HostContact, HostGroup, Ipaddress, PtrOverride
-from mreg.models.auth import User
 from mreg.models.network import NetGroupRegexPermission, Network, NetworkExcludedRange
 from mreg.models.network_policy import (
     Community,
@@ -89,6 +90,13 @@ class SnapshotUnavailable(SnapshotError):
 
 class SnapshotNotAcceptable(SnapshotRequestError):
     pass
+
+
+def _validate_snapshot_options(snapshot_format: str, include_permissions: bool) -> None:
+    if snapshot_format not in {ARCHIVE_FORMAT, JSON_FORMAT}:
+        raise SnapshotRequestError(f"Unsupported snapshot format: {snapshot_format}")
+    if include_permissions and snapshot_format != ARCHIVE_FORMAT:
+        raise SnapshotRequestError("Option 'include_permissions=true' is only supported by mreg-snapshot-v1")
 
 
 def _ref(kind: str, pk: Any) -> str:
@@ -409,53 +417,65 @@ def _split_dns_character_strings(value: str) -> list[str]:
     return chunks
 
 
-def _dns_record_items(
+_HOST_RECORD_SPECIFICATIONS = (
+    (Hinfo, "HINFO", lambda obj: {"cpu": obj.cpu, "os": obj.os}, lambda obj: obj.host.ttl),
+    (Loc, "LOC", lambda obj: _parse_loc(obj.loc, pk=obj.pk), lambda obj: obj.host.ttl),
+    (Mx, "MX", lambda obj: {"preference": obj.priority, "exchange": obj.mx}, lambda obj: obj.host.ttl),
+    (Txt, "TXT", lambda obj: {"value": _split_dns_character_strings(obj.txt)}, lambda obj: obj.host.ttl),
+    (
+        Naptr,
+        "NAPTR",
+        lambda obj: {
+            "order": obj.order,
+            "preference": obj.preference,
+            "flags": obj.flag,
+            "services": obj.service,
+            "regexp": obj.regex,
+            "replacement": obj.replacement,
+        },
+        lambda obj: obj.host.ttl,
+    ),
+    (
+        Sshfp,
+        "SSHFP",
+        lambda obj: {
+            "algorithm": obj.algorithm,
+            "fp_type": obj.hash_type,
+            "fingerprint": obj.fingerprint,
+        },
+        lambda obj: obj.ttl if obj.ttl is not None else obj.host.ttl,
+    ),
+)
+
+
+def _wildcard_address_record_items(wildcards: set[int], chunk_size: int) -> Iterator[dict[str, Any]]:
+    queryset = Ipaddress.objects.filter(host_id__in=wildcards).select_related("host").order_by("pk")
+    for obj in queryset.iterator(chunk_size=chunk_size):
+        address = ipaddress.ip_address(obj.ipaddress)
+        yield _item(
+            _ref("record_ip_address", obj.pk),
+            "record",
+            _record_attributes(
+                "A" if address.version == 4 else "AAAA",
+                obj.host.name,
+                {"address": obj.ipaddress},
+                ttl=obj.host.ttl,
+            ),
+        )
+
+
+def _host_dns_record_items(
     wildcards: set[int],
     chunk_size: int,
     *,
-    only_deferred: bool = False,
+    deferred: bool,
 ) -> Iterator[dict[str, Any]]:
-    wildcard_hosts = {pk: (name, ttl) for pk, name, ttl in Host.objects.filter(pk__in=wildcards).values_list("pk", "name", "ttl")}
-    if not only_deferred:
-        for obj in Ipaddress.objects.filter(host_id__in=wildcards).select_related("host").order_by("pk").iterator(chunk_size=chunk_size):
-            address = ipaddress.ip_address(obj.ipaddress)
-            yield _item(
-                _ref("record_ip_address", obj.pk),
-                "record",
-                _record_attributes("A" if address.version == 4 else "AAAA", obj.host.name, {"address": obj.ipaddress}, ttl=obj.host.ttl),
-            )
-
-    specifications = (
-        (Hinfo, "HINFO", lambda o: {"cpu": o.cpu, "os": o.os}, lambda o: o.host.ttl),
-        (Loc, "LOC", lambda o: _parse_loc(o.loc, pk=o.pk), lambda o: o.host.ttl),
-        (Mx, "MX", lambda o: {"preference": o.priority, "exchange": o.mx}, lambda o: o.host.ttl),
-        (Txt, "TXT", lambda o: {"value": _split_dns_character_strings(o.txt)}, lambda o: o.host.ttl),
-        (
-            Naptr,
-            "NAPTR",
-            lambda o: {
-                "order": o.order,
-                "preference": o.preference,
-                "flags": o.flag,
-                "services": o.service,
-                "regexp": o.regex,
-                "replacement": o.replacement,
-            },
-            lambda o: o.host.ttl,
-        ),
-        (
-            Sshfp,
-            "SSHFP",
-            lambda o: {"algorithm": o.algorithm, "fp_type": o.hash_type, "fingerprint": o.fingerprint},
-            lambda o: o.ttl if o.ttl is not None else o.host.ttl,
-        ),
-    )
-    for model, type_name, data_factory, ttl_factory in specifications:
+    for model, type_name, data_factory, ttl_factory in _HOST_RECORD_SPECIFICATIONS:
         queryset = model.objects.select_related("host").order_by("pk")
         for obj in queryset.iterator(chunk_size=chunk_size):
             wildcard = obj.host_id in wildcards
-            deferred = wildcard and type_name in DEFERRED_WILDCARD_RECORD_TYPES
-            if deferred != only_deferred:
+            is_deferred = wildcard and type_name in DEFERRED_WILDCARD_RECORD_TYPES
+            if is_deferred != deferred:
                 continue
             if type_name == "MX" and not wildcard:
                 owner_kind = "forward_zone"
@@ -477,18 +497,27 @@ def _dns_record_items(
                     anchor_ref=anchor_ref,
                 ),
             )
-            if deferred:
+            if is_deferred:
                 item["deferred"] = {
                     "reason": "wildcard_owner_not_supported_by_import_contract",
                     "requires_manual_handling": True,
                 }
             yield item
-    if only_deferred:
-        return
 
+
+def _standalone_dns_record_items(chunk_size: int) -> Iterator[dict[str, Any]]:
     for model, type_name, data_factory in (
-        (Cname, "CNAME", lambda o: {"target": o.host.name}),
-        (Srv, "SRV", lambda o: {"priority": o.priority, "weight": o.weight, "port": o.port, "target": o.host.name}),
+        (Cname, "CNAME", lambda obj: {"target": obj.host.name}),
+        (
+            Srv,
+            "SRV",
+            lambda obj: {
+                "priority": obj.priority,
+                "weight": obj.weight,
+                "port": obj.port,
+                "target": obj.host.name,
+            },
+        ),
     ):
         queryset = model.objects.select_related("host").order_by("pk")
         for obj in queryset.iterator(chunk_size=chunk_size):
@@ -498,17 +527,29 @@ def _dns_record_items(
                 _record_attributes(type_name, obj.name, data_factory(obj), ttl=obj.ttl),
             )
 
-    for host_id, (name, _ttl) in wildcard_hosts.items():
-        has_dns = Ipaddress.objects.filter(host_id=host_id).exists() or any(
-            model.objects.filter(host_id=host_id).exists() for model, *_ in specifications
+
+def _validate_wildcard_hosts(wildcards: set[int], chunk_size: int) -> None:
+    for host in Host.objects.filter(pk__in=wildcards).order_by("pk").iterator(chunk_size=chunk_size):
+        has_dns = Ipaddress.objects.filter(host_id=host.pk).exists() or any(
+            model.objects.filter(host_id=host.pk).exists() for model, *_ in _HOST_RECORD_SPECIFICATIONS
         )
         if not has_dns:
-            raise SnapshotError("Wildcard host has no translatable DNS data", model="Host", object_id=host_id)
-        host = Host.objects.get(pk=host_id)
+            raise SnapshotError("Wildcard host has no translatable DNS data", model="Host", object_id=host.pk)
         if host.comment or host.contacts.exists() or host.hostgroups.exists() or host.hostpolicyroles.exists():
-            raise SnapshotError("Wildcard host has non-DNS relationships", model="Host", object_id=host_id)
-        if BACnetID.objects.filter(host_id=host_id).exists() or HostCommunityMapping.objects.filter(host_id=host_id).exists():
-            raise SnapshotError("Wildcard host has non-DNS relationships", model="Host", object_id=host_id)
+            raise SnapshotError("Wildcard host has non-DNS relationships", model="Host", object_id=host.pk)
+        if BACnetID.objects.filter(host_id=host.pk).exists() or HostCommunityMapping.objects.filter(host_id=host.pk).exists():
+            raise SnapshotError("Wildcard host has non-DNS relationships", model="Host", object_id=host.pk)
+
+
+def _dns_record_items(wildcards: set[int], chunk_size: int) -> Iterator[dict[str, Any]]:
+    yield from _wildcard_address_record_items(wildcards, chunk_size)
+    yield from _host_dns_record_items(wildcards, chunk_size, deferred=False)
+    yield from _standalone_dns_record_items(chunk_size)
+    _validate_wildcard_hosts(wildcards, chunk_size)
+
+
+def _deferred_dns_record_items(wildcards: set[int], chunk_size: int) -> Iterator[dict[str, Any]]:
+    yield from _host_dns_record_items(wildcards, chunk_size, deferred=True)
 
 
 def _relationship_items(index: NetworkIndex, wildcards: set[int], chunk_size: int) -> Iterator[dict[str, Any]]:
@@ -637,23 +678,48 @@ def iter_import_items(chunk_size: int) -> Iterator[dict[str, Any]]:
 
 def iter_deferred_record_items(chunk_size: int) -> Iterator[dict[str, Any]]:
     """Yield valid source records whose automatic import must be deferred."""
-    yield from _dns_record_items(_wildcard_ids(), chunk_size, only_deferred=True)
+    yield from _deferred_dns_record_items(_wildcard_ids(), chunk_size)
 
 
-@dataclass
+@dataclass(frozen=True)
 class SnapshotArtifact:
     path: Path
-    temporary_directory: tempfile.TemporaryDirectory
+    temporary_directory: tempfile.TemporaryDirectory[str]
     digest_hex: str
     digest_base64: str
     filename: str
     content_type: str
+
+    def cleanup(self) -> None:
+        self.temporary_directory.cleanup()
 
 
 @dataclass(frozen=True)
 class SnapshotOptions:
     snapshot_format: str
     include_permissions: bool
+
+
+@dataclass(frozen=True)
+class SnapshotDataFile:
+    path: Path
+    count: int
+    sha256: str
+
+    def manifest_entry(self) -> dict[str, str | int]:
+        return {
+            "path": self.path.name,
+            "count": self.count,
+            "sha256": self.sha256,
+        }
+
+
+@dataclass(frozen=True)
+class SnapshotData:
+    items: SnapshotDataFile
+    deferred_records: SnapshotDataFile
+    permissions: SnapshotDataFile | None
+    database_timestamp: datetime
 
 
 def _json_bytes(value: Any) -> bytes:
@@ -676,7 +742,7 @@ def iter_permission_items(chunk_size: int) -> Iterator[dict[str, Any]]:
         )
 
 
-def _write_ndjson(path: Path, values: Iterable[dict[str, Any]]) -> tuple[int, str]:
+def _write_ndjson(path: Path, values: Iterable[dict[str, Any]]) -> SnapshotDataFile:
     digest = hashlib.sha256()
     count = 0
     with path.open("wb") as output:
@@ -685,15 +751,15 @@ def _write_ndjson(path: Path, values: Iterable[dict[str, Any]]) -> tuple[int, st
             output.write(encoded)
             digest.update(encoded)
             count += 1
-    return count, digest.hexdigest()
+    return SnapshotDataFile(path=path, count=count, sha256=digest.hexdigest())
 
 
 def _write_snapshot_data(
-    items_path: Path,
-    deferred_records_path: Path,
-    permissions_path: Path | None,
+    directory: Path,
     chunk_size: int,
-) -> tuple[int, str, int, str, int | None, str | None, datetime]:
+    *,
+    include_permissions: bool,
+) -> SnapshotData:
     try:
         with transaction.atomic(), connection.cursor() as cursor:
             if connection.vendor != "postgresql":
@@ -701,28 +767,23 @@ def _write_snapshot_data(
             cursor.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY")
             cursor.execute("SELECT transaction_timestamp()")
             database_timestamp = cursor.fetchone()[0]
-            item_count, item_sha256 = _write_ndjson(items_path, iter_import_items(chunk_size))
-            deferred_count, deferred_sha256 = _write_ndjson(
-                deferred_records_path,
+            items = _write_ndjson(directory / "items.ndjson", iter_import_items(chunk_size))
+            deferred_records = _write_ndjson(
+                directory / "deferred-records.ndjson",
                 iter_deferred_record_items(chunk_size),
             )
-            if permissions_path is None:
-                permission_count = None
-                permission_sha256 = None
-            else:
-                permission_count, permission_sha256 = _write_ndjson(permissions_path, iter_permission_items(chunk_size))
+            permissions = (
+                _write_ndjson(directory / "permissions.ndjson", iter_permission_items(chunk_size)) if include_permissions else None
+            )
     except SnapshotError:
         raise
     except DatabaseError as error:
         raise SnapshotUnavailable("A consistent database snapshot could not be read") from error
-    return (
-        item_count,
-        item_sha256,
-        deferred_count,
-        deferred_sha256,
-        permission_count,
-        permission_sha256,
-        database_timestamp,
+    return SnapshotData(
+        items=items,
+        deferred_records=deferred_records,
+        permissions=permissions,
+        database_timestamp=database_timestamp,
     )
 
 
@@ -737,8 +798,7 @@ def _write_json_array(output, path: Path) -> None:
 
 
 def _build_json_artifact(
-    items_path: Path,
-    deferred_records_path: Path,
+    data: SnapshotData,
     artifact_path: Path,
     requested_by: str,
     created_at: datetime,
@@ -747,16 +807,31 @@ def _build_json_artifact(
         output.write(b'{"requested_by":')
         output.write(_json_bytes(requested_by))
         output.write(b',"items":[')
-        _write_json_array(output, items_path)
+        _write_json_array(output, data.items.path)
         output.write(b'],"deferred_records":[')
-        _write_json_array(output, deferred_records_path)
+        _write_json_array(output, data.deferred_records.path)
         output.write(b"]}\n")
 
 
+def _tar_info(name: str, size: int, created_at: datetime) -> tarfile.TarInfo:
+    info = tarfile.TarInfo(name)
+    info.size = size
+    info.mtime = int(created_at.timestamp())
+    info.mode = 0o644
+    return info
+
+
+def _add_bytes_to_archive(archive: tarfile.TarFile, name: str, content: bytes, created_at: datetime) -> None:
+    archive.addfile(_tar_info(name, len(content), created_at), io.BytesIO(content))
+
+
+def _add_data_file_to_archive(archive: tarfile.TarFile, data_file: SnapshotDataFile, created_at: datetime) -> None:
+    with data_file.path.open("rb") as source:
+        archive.addfile(_tar_info(data_file.path.name, data_file.path.stat().st_size, created_at), source)
+
+
 def _build_archive(
-    items_path: Path,
-    deferred_records_path: Path,
-    permissions_path: Path | None,
+    data: SnapshotData,
     artifact_path: Path,
     manifest: dict[str, Any],
     created_at: datetime,
@@ -767,32 +842,49 @@ def _build_archive(
         gzip.GzipFile(filename="", fileobj=raw, mode="wb", mtime=int(created_at.timestamp())) as compressed,
     ):
         with tarfile.open(fileobj=compressed, mode="w", format=tarfile.USTAR_FORMAT) as archive:
-            info = tarfile.TarInfo("manifest.json")
-            info.size = len(manifest_bytes)
-            info.mtime = int(created_at.timestamp())
-            info.mode = 0o644
-            import io
+            _add_bytes_to_archive(archive, "manifest.json", manifest_bytes, created_at)
+            _add_data_file_to_archive(archive, data.items, created_at)
+            _add_data_file_to_archive(archive, data.deferred_records, created_at)
+            if data.permissions is not None:
+                _add_data_file_to_archive(archive, data.permissions, created_at)
 
-            archive.addfile(info, io.BytesIO(manifest_bytes))
-            info = tarfile.TarInfo("items.ndjson")
-            info.size = items_path.stat().st_size
-            info.mtime = int(created_at.timestamp())
-            info.mode = 0o644
-            with items_path.open("rb") as items:
-                archive.addfile(info, items)
-            info = tarfile.TarInfo("deferred-records.ndjson")
-            info.size = deferred_records_path.stat().st_size
-            info.mtime = int(created_at.timestamp())
-            info.mode = 0o644
-            with deferred_records_path.open("rb") as deferred_records:
-                archive.addfile(info, deferred_records)
-            if permissions_path is not None:
-                info = tarfile.TarInfo("permissions.ndjson")
-                info.size = permissions_path.stat().st_size
-                info.mtime = int(created_at.timestamp())
-                info.mode = 0o644
-                with permissions_path.open("rb") as permissions:
-                    archive.addfile(info, permissions)
+
+def _build_manifest(data: SnapshotData, created_at: datetime, instance: str) -> dict[str, Any]:
+    permissions_included = data.permissions is not None
+    return {
+        "format": "no.uio.mreg.snapshot",
+        "format_version": 1,
+        "created_at": created_at.isoformat().replace("+00:00", "Z"),
+        "source": {"product": "django-mreg", "version": __version__, "instance": instance},
+        "snapshot": {
+            "consistent": True,
+            "database_timestamp": data.database_timestamp.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
+        },
+        "items": data.items.manifest_entry(),
+        "deferred_records": data.deferred_records.manifest_entry(),
+        "permissions": data.permissions.manifest_entry() if data.permissions is not None else None,
+        "semantics": {
+            "dependency_ordered": True,
+            "generated_records_omitted": [
+                "A_from_ip_assignment",
+                "AAAA_from_ip_assignment",
+                "PTR_from_ip_assignment",
+                "NS_from_zone",
+            ],
+            "audit_included": False,
+            "permissions_included": permissions_included,
+            "redacted": False,
+            "fully_importable": data.deferred_records.count == 0,
+        },
+    }
+
+
+def _artifact_digest(path: Path) -> tuple[str, str]:
+    digest = hashlib.sha256()
+    with path.open("rb") as artifact:
+        while chunk := artifact.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest(), base64.b64encode(digest.digest()).decode("ascii")
 
 
 def create_snapshot_artifact(
@@ -802,99 +894,34 @@ def create_snapshot_artifact(
     *,
     include_permissions: bool = False,
 ) -> SnapshotArtifact:
+    _validate_snapshot_options(snapshot_format, include_permissions)
     temporary_directory = tempfile.TemporaryDirectory(dir=settings.MREG_SNAPSHOT_TMPDIR)
     directory = Path(temporary_directory.name)
     created_at = datetime.now(timezone.utc).replace(microsecond=0)
-    items_path = directory / "items.ndjson"
-    deferred_records_path = directory / "deferred-records.ndjson"
-    permissions_path = directory / "permissions.ndjson" if include_permissions else None
     try:
-        (
-            count,
-            items_sha256,
-            deferred_count,
-            deferred_sha256,
-            permission_count,
-            permission_sha256,
-            database_timestamp,
-        ) = _write_snapshot_data(
-            items_path,
-            deferred_records_path,
-            permissions_path,
+        data = _write_snapshot_data(
+            directory,
             settings.MREG_SNAPSHOT_CHUNK_SIZE,
+            include_permissions=include_permissions,
         )
-        if count == 0:
+        if data.items.count == 0:
             raise SnapshotError("The source contains no snapshot items")
         timestamp = created_at.strftime("%Y%m%dT%H%M%SZ")
         if snapshot_format == ARCHIVE_FORMAT:
             artifact_path = directory / f"mreg-snapshot-{timestamp}-v1.tar.gz"
-            manifest = {
-                "format": "no.uio.mreg.snapshot",
-                "format_version": 1,
-                "created_at": created_at.isoformat().replace("+00:00", "Z"),
-                "source": {"product": "django-mreg", "version": __version__, "instance": instance},
-                "snapshot": {
-                    "consistent": True,
-                    "database_timestamp": database_timestamp.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
-                },
-                "items": {"path": "items.ndjson", "count": count, "sha256": items_sha256},
-                "deferred_records": {
-                    "path": "deferred-records.ndjson",
-                    "count": deferred_count,
-                    "sha256": deferred_sha256,
-                },
-                "permissions": (
-                    {
-                        "path": "permissions.ndjson",
-                        "count": permission_count,
-                        "sha256": permission_sha256,
-                    }
-                    if include_permissions
-                    else None
-                ),
-                "semantics": {
-                    "dependency_ordered": True,
-                    "generated_records_omitted": [
-                        "A_from_ip_assignment",
-                        "AAAA_from_ip_assignment",
-                        "PTR_from_ip_assignment",
-                        "NS_from_zone",
-                    ],
-                    "audit_included": False,
-                    "permissions_included": include_permissions,
-                    "redacted": False,
-                    "fully_importable": deferred_count == 0,
-                },
-            }
-            _build_archive(
-                items_path,
-                deferred_records_path,
-                permissions_path,
-                artifact_path,
-                manifest,
-                created_at,
-            )
+            manifest = _build_manifest(data, created_at, instance)
+            _build_archive(data, artifact_path, manifest, created_at)
             content_type = ARCHIVE_MEDIA_TYPE
         else:
             artifact_path = directory / f"mreg-import-{timestamp}-v1.json.gz"
-            _build_json_artifact(
-                items_path,
-                deferred_records_path,
-                artifact_path,
-                requested_by,
-                created_at,
-            )
+            _build_json_artifact(data, artifact_path, requested_by, created_at)
             content_type = JSON_MEDIA_TYPE
-        digest = hashlib.sha256()
-        with artifact_path.open("rb") as artifact:
-            while chunk := artifact.read(1024 * 1024):
-                digest.update(chunk)
-        digest_bytes = digest.digest()
+        digest_hex, digest_base64 = _artifact_digest(artifact_path)
         return SnapshotArtifact(
             path=artifact_path,
             temporary_directory=temporary_directory,
-            digest_hex=digest.hexdigest(),
-            digest_base64=base64.b64encode(digest_bytes).decode("ascii"),
+            digest_hex=digest_hex,
+            digest_base64=digest_base64,
             filename=artifact_path.name,
             content_type=content_type,
         )
@@ -906,13 +933,21 @@ def create_snapshot_artifact(
 class SnapshotFileResponse(FileResponse):
     def __init__(self, artifact: SnapshotArtifact):
         self.artifact = artifact
-        super().__init__(artifact.path.open("rb"), as_attachment=True, filename=artifact.filename, content_type=artifact.content_type)
+        source = None
+        try:
+            source = artifact.path.open("rb")
+            super().__init__(source, as_attachment=True, filename=artifact.filename, content_type=artifact.content_type)
+        except Exception:
+            if source is not None:
+                source.close()
+            artifact.cleanup()
+            raise
 
-    def close(self):
+    def close(self) -> None:
         try:
             super().close()
         finally:
-            self.artifact.temporary_directory.cleanup()
+            self.artifact.cleanup()
 
 
 def _error_response(code: str, message: str, status_code: int, error: SnapshotError | None = None) -> Response:
@@ -959,14 +994,11 @@ def _parse_request(request) -> SnapshotOptions:
         if len(request.query_params.getlist(key)) > 1:
             raise SnapshotRequestError(f"Query parameter {key!r} may only be supplied once")
     snapshot_format = request.query_params.get("format", ARCHIVE_FORMAT)
-    if snapshot_format not in {ARCHIVE_FORMAT, JSON_FORMAT}:
-        raise SnapshotRequestError(f"Unsupported snapshot format: {snapshot_format}")
     include_permissions_value = request.query_params.get("include_permissions", "false")
     if include_permissions_value not in {"false", "true"}:
         raise SnapshotRequestError("Option 'include_permissions' must be 'true' or 'false'")
     include_permissions = include_permissions_value == "true"
-    if include_permissions and snapshot_format != ARCHIVE_FORMAT:
-        raise SnapshotRequestError("Option 'include_permissions=true' is only supported by mreg-snapshot-v1")
+    _validate_snapshot_options(snapshot_format, include_permissions)
     for key, expected in SUPPORTED_OPTIONS.items():
         actual = request.query_params.get(key, expected)
         if actual != expected:
@@ -982,16 +1014,19 @@ def _parse_request(request) -> SnapshotOptions:
 
 
 class SnapshotView(APIView):
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (IsSnapshotGroupMember,)
     renderer_classes = (SnapshotArchiveRenderer, SnapshotJSONRenderer)
 
-    def get(self, request):
-        if not User.from_request(request).is_mreg_snapshotter:
+    def handle_exception(self, exc: Exception) -> Response:
+        if isinstance(exc, PermissionDenied):
             return _error_response(
                 "snapshot_forbidden",
                 "The principal does not have snapshot permission",
                 403,
             )
+        return super().handle_exception(exc)
+
+    def get(self, request):
         try:
             options = _parse_request(request)
             artifact = create_snapshot_artifact(

--- a/mreg/api/v1/snapshot.py
+++ b/mreg/api/v1/snapshot.py
@@ -1,0 +1,910 @@
+"""Synchronous, versioned portable snapshots."""
+
+from __future__ import annotations
+
+import base64
+import gzip
+import hashlib
+import ipaddress
+import json
+import tarfile
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+from django.conf import settings
+from django.db import DatabaseError, connection, transaction
+from django.db.models import Count
+from django.http import FileResponse
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from hostpolicy.models import HostPolicyAtom, HostPolicyRole
+from mreg import __version__
+from mreg.api.permissions import IsAuthenticated
+from mreg.models.base import Label, NameServer
+from mreg.models.host import BACnetID, Host, HostContact, HostGroup, Ipaddress, PtrOverride
+from mreg.models.auth import User
+from mreg.models.network import NetGroupRegexPermission, Network, NetworkExcludedRange
+from mreg.models.network_policy import (
+    Community,
+    HostCommunityMapping,
+    NetworkPolicy,
+    NetworkPolicyAttribute,
+    NetworkPolicyAttributeValue,
+)
+from mreg.models.resource_records import Cname, Hinfo, Loc, Mx, Naptr, Srv, Sshfp, Txt
+from mreg.models.zone import (
+    ForwardZone,
+    ForwardZoneDelegation,
+    ReverseZone,
+    ReverseZoneDelegation,
+)
+
+
+ARCHIVE_FORMAT = "mreg-snapshot-v1"
+JSON_FORMAT = "mreg-import-json-v1"
+ARCHIVE_MEDIA_TYPE = "application/vnd.uio.mreg-snapshot+tar"
+JSON_MEDIA_TYPE = "application/json"
+SUPPORTED_OPTIONS = {
+    "include_audit": "false",
+    "validate": "true",
+    "redact": "false",
+}
+
+
+class SnapshotError(Exception):
+    """An error safe to report to a snapshot client."""
+
+    def __init__(self, message: str, *, model: str | None = None, object_id: Any = None):
+        super().__init__(message)
+        self.model = model
+        self.object_id = object_id
+
+
+class SnapshotRequestError(SnapshotError):
+    pass
+
+
+class SnapshotUnavailable(SnapshotError):
+    pass
+
+
+class SnapshotNotAcceptable(SnapshotRequestError):
+    pass
+
+
+def _ref(kind: str, pk: Any) -> str:
+    return f"{kind}:{pk}"
+
+
+def _item(reference: str, kind: str, attributes: dict[str, Any]) -> dict[str, Any]:
+    return {"ref": reference, "kind": kind, "operation": "create", "attributes": attributes}
+
+
+def _without_none(data: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in data.items() if value is not None}
+
+
+def _normalized_mac(value: str) -> str | None:
+    if not value:
+        return None
+    compact = "".join(character for character in value.lower() if character.isalnum())
+    if len(compact) != 12:
+        raise SnapshotError(f"Invalid MAC address {value!r}")
+    return ":".join(compact[index:index + 2] for index in range(0, 12, 2))
+
+
+class NetworkIndex:
+    """Small longest-prefix-match index for legacy IP rows."""
+
+    def __init__(self) -> None:
+        self.by_family: dict[int, dict[int, dict[str, tuple[int, str]]]] = {4: {}, 6: {}}
+        for pk, value in Network.objects.order_by("pk").values_list("pk", "network"):
+            network = ipaddress.ip_network(str(value))
+            self.by_family[network.version].setdefault(network.prefixlen, {})[str(network)] = (pk, str(network))
+
+    def match(self, value: str) -> tuple[int, str] | None:
+        address = ipaddress.ip_address(value)
+        by_prefix = self.by_family[address.version]
+        for prefix in sorted(by_prefix, reverse=True):
+            candidate = str(ipaddress.ip_network(f"{address}/{prefix}", strict=False))
+            if candidate in by_prefix[prefix]:
+                return by_prefix[prefix][candidate]
+        return None
+
+
+def _attachment_ref(host_id: int, network_id: int, mac: str | None) -> str:
+    suffix = mac.replace(":", "") if mac else "none"
+    return f"host_attachment:{host_id}:{network_id}:{suffix}"
+
+
+def _base_items(chunk_size: int) -> Iterator[dict[str, Any]]:
+    for obj in Label.objects.order_by("pk").iterator(chunk_size=chunk_size):
+        yield _item(_ref("label", obj.pk), "label", {"name": obj.name, "description": obj.description})
+    for obj in NameServer.objects.order_by("pk").iterator(chunk_size=chunk_size):
+        yield _item(_ref("nameserver", obj.pk), "nameserver", _without_none({"name": obj.name, "ttl": obj.ttl}))
+    for obj in NetworkPolicyAttribute.objects.order_by("pk").iterator(chunk_size=chunk_size):
+        yield _item(
+            _ref("network_policy_attribute", obj.pk),
+            "network_policy_attribute",
+            {"name": obj.name, "description": obj.description},
+        )
+    for obj in NetworkPolicy.objects.order_by("pk").iterator(chunk_size=chunk_size):
+        yield _item(
+            _ref("network_policy", obj.pk),
+            "network_policy",
+            _without_none(
+                {
+                    "name": obj.name,
+                    "description": obj.description,
+                    "community_template_pattern": obj.community_template_pattern,
+                }
+            ),
+        )
+    values = NetworkPolicyAttributeValue.objects.select_related("policy", "attribute").order_by("pk")
+    for obj in values.iterator(chunk_size=chunk_size):
+        yield _item(
+            _ref("network_policy_attribute_value", obj.pk),
+            "network_policy_attribute_value",
+            {
+                "policy_name_ref": _ref("network_policy", obj.policy_id),
+                "attribute_name_ref": _ref("network_policy_attribute", obj.attribute_id),
+                "value": obj.value,
+            },
+        )
+
+
+def _network_zone_items(chunk_size: int) -> Iterator[dict[str, Any]]:
+    for obj in Network.objects.order_by("pk").iterator(chunk_size=chunk_size):
+        yield _item(
+            _ref("network", obj.pk),
+            "network",
+            _without_none(
+                {
+                    "cidr": str(obj.network),
+                    "description": obj.description,
+                    "vlan": obj.vlan,
+                    "dns_delegated": obj.dns_delegated,
+                    "category": obj.category,
+                    "location": obj.location,
+                    "frozen": obj.frozen,
+                    "reserved": obj.reserved,
+                    "max_communities": obj.max_communities,
+                    "policy_ref": _ref("network_policy", obj.policy_id) if obj.policy_id else None,
+                }
+            ),
+        )
+    ranges = NetworkExcludedRange.objects.select_related("network").order_by("pk")
+    for obj in ranges.iterator(chunk_size=chunk_size):
+        yield _item(
+            _ref("excluded_range", obj.pk),
+            "excluded_range",
+            {
+                "network_ref": _ref("network", obj.network_id),
+                "start_ip": obj.start_ip,
+                "end_ip": obj.end_ip,
+                "description": "",
+            },
+        )
+    communities = Community.objects.select_related("network__policy").order_by("pk")
+    for obj in communities.iterator(chunk_size=chunk_size):
+        if obj.network.policy_id is None:
+            raise SnapshotError(
+                "Community references a network without a policy", model="Community", object_id=obj.pk
+            )
+        yield _item(
+            _ref("community", obj.pk),
+            "community",
+            {
+                "policy_name_ref": _ref("network_policy", obj.network.policy_id),
+                "network_cidr_ref": _ref("network", obj.network_id),
+                "name": obj.name,
+                "description": obj.description,
+            },
+        )
+    yield from _zone_items(ForwardZone, "forward_zone", chunk_size)
+    yield from _zone_items(ReverseZone, "reverse_zone", chunk_size)
+    yield from _delegation_items(ForwardZoneDelegation, "forward_zone_delegation", "forward_zone", chunk_size)
+    yield from _delegation_items(ReverseZoneDelegation, "reverse_zone_delegation", "reverse_zone", chunk_size)
+
+
+def _zone_items(model, kind: str, chunk_size: int) -> Iterator[dict[str, Any]]:
+    queryset = model.objects.prefetch_related("nameservers").order_by("pk")
+    for obj in queryset.iterator(chunk_size=chunk_size):
+        attributes = {
+            "name": obj.name,
+            "primary_ns": obj.primary_ns,
+            "nameservers": [_ref("nameserver", ns.pk) for ns in obj.nameservers.all()],
+            "email": obj.email,
+            "serial_no": obj.serialno,
+            "refresh": obj.refresh,
+            "retry": obj.retry,
+            "expire": obj.expire,
+            "soa_ttl": obj.soa_ttl,
+            "default_ttl": obj.default_ttl,
+        }
+        if kind == "reverse_zone":
+            attributes["network"] = str(obj.network)
+        yield _item(_ref(kind, obj.pk), kind, attributes)
+
+
+def _delegation_items(model, kind: str, zone_kind: str, chunk_size: int) -> Iterator[dict[str, Any]]:
+    queryset = model.objects.prefetch_related("nameservers").order_by("pk")
+    for obj in queryset.iterator(chunk_size=chunk_size):
+        yield _item(
+            _ref(kind, obj.pk),
+            kind,
+            {
+                "zone_ref": _ref(zone_kind, obj.zone_id),
+                "name": obj.name,
+                "comment": obj.comment,
+                "nameservers": [_ref("nameserver", ns.pk) for ns in obj.nameservers.all()],
+            },
+        )
+
+
+def _wildcard_ids() -> set[int]:
+    return set(Host.objects.filter(name__contains="*").values_list("pk", flat=True))
+
+
+def _host_items(wildcards: set[int], chunk_size: int) -> Iterator[dict[str, Any]]:
+    queryset = Host.objects.exclude(pk__in=wildcards).order_by("pk")
+    for obj in queryset.iterator(chunk_size=chunk_size):
+        yield _item(
+            _ref("host", obj.pk),
+            "host",
+            _without_none(
+                {
+                    "name": obj.name,
+                    "zone_ref": _ref("forward_zone", obj.zone_id) if obj.zone_id else None,
+                    "ttl": obj.ttl,
+                    "comment": obj.comment,
+                }
+            ),
+        )
+
+
+def _ip_rows(chunk_size: int):
+    return Ipaddress.objects.select_related("host").order_by("host_id", "pk").iterator(chunk_size=chunk_size)
+
+
+def _attachment_items(index: NetworkIndex, wildcards: set[int], chunk_size: int) -> Iterator[dict[str, Any]]:
+    seen_for_host: set[str] = set()
+    current_host = None
+    for obj in _ip_rows(chunk_size):
+        if obj.host_id in wildcards:
+            if obj.macaddress:
+                raise SnapshotError(
+                    "Wildcard IP assignment has a MAC address that cannot be represented",
+                    model="Ipaddress",
+                    object_id=obj.pk,
+                )
+            continue
+        if current_host != obj.host_id:
+            current_host = obj.host_id
+            seen_for_host.clear()
+        match = index.match(obj.ipaddress)
+        if match is None:
+            raise SnapshotError("IP address is not contained in a network", model="Ipaddress", object_id=obj.pk)
+        network_id, network = match
+        mac = _normalized_mac(obj.macaddress)
+        reference = _attachment_ref(obj.host_id, network_id, mac)
+        if reference in seen_for_host:
+            continue
+        seen_for_host.add(reference)
+        yield _item(
+            reference,
+            "host_attachment",
+            _without_none(
+                {
+                    "host_name_ref": _ref("host", obj.host_id),
+                    "network_ref": _ref("network", network_id),
+                    "mac_address": mac,
+                }
+            ),
+        )
+
+
+def _ip_items(index: NetworkIndex, wildcards: set[int], chunk_size: int) -> Iterator[dict[str, Any]]:
+    duplicate = (
+        Ipaddress.objects.values("ipaddress").annotate(count=Count("pk")).filter(count__gt=1).order_by("ipaddress").first()
+    )
+    if duplicate:
+        raise SnapshotError(f"IP address {duplicate['ipaddress']} is assigned more than once", model="Ipaddress")
+    for obj in _ip_rows(chunk_size):
+        if obj.host_id in wildcards:
+            continue
+        match = index.match(obj.ipaddress)
+        if match is None:
+            raise SnapshotError("IP address is not contained in a network", model="Ipaddress", object_id=obj.pk)
+        network_id, _ = match
+        mac = _normalized_mac(obj.macaddress)
+        yield _item(
+            _ref("ip_address", obj.pk),
+            "ip_address",
+            {"attachment_id_ref": _attachment_ref(obj.host_id, network_id, mac), "address": obj.ipaddress},
+        )
+
+
+def _record_attributes(
+    type_name: str,
+    owner_name: str,
+    data: dict[str, Any],
+    *,
+    ttl: int | None = None,
+    owner_kind: str | None = None,
+    anchor_ref: str | None = None,
+) -> dict[str, Any]:
+    return _without_none(
+        {
+            "type_name": type_name,
+            "owner_kind": owner_kind,
+            "owner_name": owner_name,
+            "anchor_name_ref": anchor_ref,
+            "ttl": ttl,
+            "data": data,
+        }
+    )
+
+
+def _parse_loc(value: str, *, pk: Any) -> dict[str, float]:
+    tokens = value.split()
+    try:
+        lat_end = tokens.index("N") if "N" in tokens else tokens.index("S")
+        lon_start = lat_end + 1
+        lon_end = tokens.index("E") if "E" in tokens else tokens.index("W")
+
+        def coordinate(parts: list[str], direction: str) -> float:
+            numbers = [float(part) for part in parts]
+            result = numbers[0]
+            if len(numbers) > 1:
+                result += numbers[1] / 60
+            if len(numbers) > 2:
+                result += numbers[2] / 3600
+            return -result if direction in {"S", "W"} else result
+
+        remaining = [float(token.removesuffix("m")) for token in tokens[lon_end + 1:]]
+        if not remaining:
+            raise ValueError("missing altitude")
+        result = {
+            "latitude": coordinate(tokens[:lat_end], tokens[lat_end]),
+            "longitude": coordinate(tokens[lon_start:lon_end], tokens[lon_end]),
+            "altitude_m": remaining[0],
+        }
+        for key, number in zip(
+            ("size_m", "horizontal_precision_m", "vertical_precision_m"), remaining[1:], strict=False
+        ):
+            result[key] = number
+        return result
+    except (ValueError, IndexError) as error:
+        raise SnapshotError("LOC value cannot be translated", model="Loc", object_id=pk) from error
+
+
+def _dns_record_items(wildcards: set[int], chunk_size: int) -> Iterator[dict[str, Any]]:
+    wildcard_hosts = {pk: (name, ttl) for pk, name, ttl in Host.objects.filter(pk__in=wildcards).values_list("pk", "name", "ttl")}
+    for obj in Ipaddress.objects.filter(host_id__in=wildcards).select_related("host").order_by("pk").iterator(chunk_size=chunk_size):
+        address = ipaddress.ip_address(obj.ipaddress)
+        yield _item(
+            _ref("record_ip_address", obj.pk),
+            "record",
+            _record_attributes("A" if address.version == 4 else "AAAA", obj.host.name, {"address": obj.ipaddress}, ttl=obj.host.ttl),
+        )
+
+    specifications = (
+        (Hinfo, "HINFO", lambda o: {"cpu": o.cpu, "os": o.os}, lambda o: o.host.ttl),
+        (Loc, "LOC", lambda o: _parse_loc(o.loc, pk=o.pk), lambda o: o.host.ttl),
+        (Mx, "MX", lambda o: {"preference": o.priority, "exchange": o.mx}, lambda o: o.host.ttl),
+        (Txt, "TXT", lambda o: {"value": o.txt}, lambda o: o.host.ttl),
+        (
+            Naptr,
+            "NAPTR",
+            lambda o: {
+                "order": o.order,
+                "preference": o.preference,
+                "flags": o.flag,
+                "services": o.service,
+                "regexp": o.regex,
+                "replacement": o.replacement,
+            },
+            lambda o: o.host.ttl,
+        ),
+        (
+            Sshfp,
+            "SSHFP",
+            lambda o: {"algorithm": o.algorithm, "fp_type": o.hash_type, "fingerprint": o.fingerprint},
+            lambda o: o.ttl if o.ttl is not None else o.host.ttl,
+        ),
+    )
+    for model, type_name, data_factory, ttl_factory in specifications:
+        queryset = model.objects.select_related("host").order_by("pk")
+        for obj in queryset.iterator(chunk_size=chunk_size):
+            wildcard = obj.host_id in wildcards
+            if type_name == "MX" and not wildcard:
+                owner_kind = "forward_zone"
+                anchor_ref = _ref("forward_zone", obj.host.zone_id) if obj.host.zone_id else None
+                if anchor_ref is None:
+                    raise SnapshotError("MX owner has no forward zone", model="Mx", object_id=obj.pk)
+            else:
+                owner_kind = None if wildcard else "host"
+                anchor_ref = None if wildcard else _ref("host", obj.host_id)
+            yield _item(
+                _ref(f"record_{model._meta.model_name}", obj.pk),
+                "record",
+                _record_attributes(
+                    type_name,
+                    obj.host.name,
+                    data_factory(obj),
+                    ttl=ttl_factory(obj),
+                    owner_kind=owner_kind,
+                    anchor_ref=anchor_ref,
+                ),
+            )
+    for model, type_name, data_factory in (
+        (Cname, "CNAME", lambda o: {"target": o.host.name}),
+        (Srv, "SRV", lambda o: {"priority": o.priority, "weight": o.weight, "port": o.port, "target": o.host.name}),
+    ):
+        queryset = model.objects.select_related("host").order_by("pk")
+        for obj in queryset.iterator(chunk_size=chunk_size):
+            yield _item(
+                _ref(f"record_{model._meta.model_name}", obj.pk),
+                "record",
+                _record_attributes(type_name, obj.name, data_factory(obj), ttl=obj.ttl),
+            )
+
+    for host_id, (name, _ttl) in wildcard_hosts.items():
+        has_dns = Ipaddress.objects.filter(host_id=host_id).exists() or any(
+            model.objects.filter(host_id=host_id).exists() for model, *_ in specifications
+        )
+        if not has_dns:
+            raise SnapshotError("Wildcard host has no translatable DNS data", model="Host", object_id=host_id)
+        host = Host.objects.get(pk=host_id)
+        if host.comment or host.contacts.exists() or host.hostgroups.exists() or host.hostpolicyroles.exists():
+            raise SnapshotError("Wildcard host has non-DNS relationships", model="Host", object_id=host_id)
+        if BACnetID.objects.filter(host_id=host_id).exists() or HostCommunityMapping.objects.filter(host_id=host_id).exists():
+            raise SnapshotError("Wildcard host has non-DNS relationships", model="Host", object_id=host_id)
+
+
+def _relationship_items(index: NetworkIndex, wildcards: set[int], chunk_size: int) -> Iterator[dict[str, Any]]:
+    ptrs = PtrOverride.objects.select_related("host").order_by("pk")
+    for obj in ptrs.iterator(chunk_size=chunk_size):
+        if obj.host_id in wildcards:
+            raise SnapshotError("Wildcard PTR override cannot be translated", model="PtrOverride", object_id=obj.pk)
+        yield _item(
+            _ref("ptr_override", obj.pk),
+            "ptr_override",
+            {"host_name_ref": _ref("host", obj.host_id), "address": obj.ipaddress},
+        )
+    for obj in BACnetID.objects.order_by("pk").iterator(chunk_size=chunk_size):
+        if obj.host_id in wildcards:
+            continue
+        yield _item(
+            _ref("bacnet_id", obj.pk),
+            "bacnet_id",
+            {"bacnet_id": obj.pk, "host_name_ref": _ref("host", obj.host_id)},
+        )
+    contacts = HostContact.objects.prefetch_related("hosts").order_by("pk")
+    for obj in contacts.iterator(chunk_size=chunk_size):
+        hosts = [_ref("host", host.pk) for host in obj.hosts.all() if host.pk not in wildcards]
+        if hosts:
+            yield _item(_ref("host_contact", obj.pk), "host_contact", {"email": obj.email, "hosts": hosts})
+    yield from _host_group_items(wildcards)
+
+    mappings = HostCommunityMapping.objects.select_related("ipaddress", "community__network").order_by("pk")
+    seen: dict[str, int] = {}
+    for obj in mappings.iterator(chunk_size=chunk_size):
+        if obj.host_id in wildcards:
+            continue
+        match = index.match(obj.ipaddress.ipaddress)
+        if match is None:
+            raise SnapshotError("Community IP is not contained in a network", model="HostCommunityMapping", object_id=obj.pk)
+        network_id, _ = match
+        mac = _normalized_mac(obj.ipaddress.macaddress)
+        attachment = _attachment_ref(obj.host_id, network_id, mac)
+        if obj.community.network_id != network_id:
+            raise SnapshotError("Community does not match the IP network", model="HostCommunityMapping", object_id=obj.pk)
+        previous = seen.get(attachment)
+        if previous is not None and previous != obj.community_id:
+            raise SnapshotError(
+                "One attachment maps to conflicting legacy communities", model="HostCommunityMapping", object_id=obj.pk
+            )
+        if previous is not None:
+            continue
+        seen[attachment] = obj.community_id
+        policy_id = obj.community.network.policy_id
+        if policy_id is None:
+            raise SnapshotError("Community network has no policy", model="HostCommunityMapping", object_id=obj.pk)
+        yield _item(
+            _ref("attachment_community_assignment", obj.pk),
+            "attachment_community_assignment",
+            {
+                "attachment_id_ref": attachment,
+                "policy_name_ref": _ref("network_policy", policy_id),
+                "community_name_ref": _ref("community", obj.community_id),
+            },
+        )
+
+
+def _host_group_items(wildcards: set[int]) -> Iterator[dict[str, Any]]:
+    groups = list(HostGroup.objects.prefetch_related("parent", "hosts", "owners").order_by("pk"))
+    pending = {group.pk: group for group in groups}
+    emitted: set[int] = set()
+    while pending:
+        ready = [group for group in pending.values() if {parent.pk for parent in group.parent.all()} <= emitted]
+        if not ready:
+            group = min(pending.values(), key=lambda value: value.pk)
+            raise SnapshotError("Host group parent relationships contain a cycle", model="HostGroup", object_id=group.pk)
+        for group in sorted(ready, key=lambda value: value.pk):
+            yield _item(
+                _ref("host_group", group.pk),
+                "host_group",
+                {
+                    "name": group.name,
+                    "description": group.description,
+                    "hosts": [_ref("host", host.pk) for host in group.hosts.all() if host.pk not in wildcards],
+                    "parent_groups": [_ref("host_group", parent.pk) for parent in group.parent.all()],
+                    "owner_groups": [owner.name for owner in group.owners.all()],
+                },
+            )
+            emitted.add(group.pk)
+            del pending[group.pk]
+
+
+def _host_policy_items(wildcards: set[int], chunk_size: int) -> Iterator[dict[str, Any]]:
+    for obj in HostPolicyAtom.objects.order_by("pk").iterator(chunk_size=chunk_size):
+        yield _item(_ref("host_policy_atom", obj.pk), "host_policy_atom", {"name": obj.name, "description": obj.description})
+    roles = HostPolicyRole.objects.prefetch_related("atoms", "hosts", "labels").order_by("pk")
+    for obj in roles.iterator(chunk_size=chunk_size):
+        yield _item(_ref("host_policy_role", obj.pk), "host_policy_role", {"name": obj.name, "description": obj.description})
+    for role in roles.iterator(chunk_size=chunk_size):
+        for atom in role.atoms.all():
+            yield _item(
+                f"host_policy_role_atom:{role.pk}:{atom.pk}",
+                "host_policy_role_atom",
+                {"role_name_ref": _ref("host_policy_role", role.pk), "atom_name_ref": _ref("host_policy_atom", atom.pk)},
+            )
+        for host in role.hosts.all():
+            if host.pk not in wildcards:
+                yield _item(
+                    f"host_policy_role_host:{role.pk}:{host.pk}",
+                    "host_policy_role_host",
+                    {"role_name_ref": _ref("host_policy_role", role.pk), "host_name_ref": _ref("host", host.pk)},
+                )
+        for label in role.labels.all():
+            yield _item(
+                f"host_policy_role_label:{role.pk}:{label.pk}",
+                "host_policy_role_label",
+                {"role_name_ref": _ref("host_policy_role", role.pk), "label_name_ref": _ref("label", label.pk)},
+            )
+
+
+def iter_import_items(chunk_size: int) -> Iterator[dict[str, Any]]:
+    wildcards = _wildcard_ids()
+    index = NetworkIndex()
+    yield from _base_items(chunk_size)
+    yield from _network_zone_items(chunk_size)
+    yield from _host_items(wildcards, chunk_size)
+    yield from _attachment_items(index, wildcards, chunk_size)
+    yield from _ip_items(index, wildcards, chunk_size)
+    yield from _dns_record_items(wildcards, chunk_size)
+    yield from _relationship_items(index, wildcards, chunk_size)
+    yield from _host_policy_items(wildcards, chunk_size)
+
+
+@dataclass
+class SnapshotArtifact:
+    path: Path
+    temporary_directory: tempfile.TemporaryDirectory
+    digest_hex: str
+    digest_base64: str
+    filename: str
+    content_type: str
+
+
+@dataclass(frozen=True)
+class SnapshotOptions:
+    snapshot_format: str
+    include_permissions: bool
+
+
+def _json_bytes(value: Any) -> bytes:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+
+
+def iter_permission_items(chunk_size: int) -> Iterator[dict[str, Any]]:
+    """Yield legacy authorization rules separately from portable domain items."""
+    queryset = NetGroupRegexPermission.objects.prefetch_related("labels").order_by("pk")
+    for permission in queryset.iterator(chunk_size=chunk_size):
+        yield _item(
+            _ref("netgroup_regex_permission", permission.pk),
+            "netgroup_regex_permission",
+            {
+                "group": permission.group,
+                "range": str(permission.range),
+                "regex": permission.regex,
+                "labels": [label.name for label in permission.labels.all()],
+            },
+        )
+
+
+def _write_ndjson(path: Path, values: Iterable[dict[str, Any]]) -> tuple[int, str]:
+    digest = hashlib.sha256()
+    count = 0
+    with path.open("wb") as output:
+        for value in values:
+            encoded = _json_bytes(value) + b"\n"
+            output.write(encoded)
+            digest.update(encoded)
+            count += 1
+    return count, digest.hexdigest()
+
+
+def _write_snapshot_data(
+    items_path: Path,
+    permissions_path: Path | None,
+    chunk_size: int,
+) -> tuple[int, str, int | None, str | None, datetime]:
+    try:
+        with transaction.atomic(), connection.cursor() as cursor:
+            if connection.vendor != "postgresql":
+                raise SnapshotUnavailable("A consistent PostgreSQL snapshot cannot be obtained")
+            cursor.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY")
+            cursor.execute("SELECT transaction_timestamp()")
+            database_timestamp = cursor.fetchone()[0]
+            item_count, item_sha256 = _write_ndjson(items_path, iter_import_items(chunk_size))
+            if permissions_path is None:
+                permission_count = None
+                permission_sha256 = None
+            else:
+                permission_count, permission_sha256 = _write_ndjson(
+                    permissions_path, iter_permission_items(chunk_size)
+                )
+    except SnapshotError:
+        raise
+    except DatabaseError as error:
+        raise SnapshotUnavailable("A consistent database snapshot could not be read") from error
+    return item_count, item_sha256, permission_count, permission_sha256, database_timestamp
+
+
+def _build_json_artifact(items_path: Path, artifact_path: Path, requested_by: str, created_at: datetime) -> None:
+    with artifact_path.open("wb") as raw, gzip.GzipFile(
+        filename="", fileobj=raw, mode="wb", mtime=int(created_at.timestamp())
+    ) as output:
+        output.write(b'{"requested_by":')
+        output.write(_json_bytes(requested_by))
+        output.write(b',"items":[')
+        first = True
+        with items_path.open("rb") as items:
+            for line in items:
+                if not first:
+                    output.write(b",")
+                output.write(line.rstrip(b"\n"))
+                first = False
+        output.write(b"]}\n")
+
+
+def _build_archive(
+    items_path: Path,
+    permissions_path: Path | None,
+    artifact_path: Path,
+    manifest: dict[str, Any],
+    created_at: datetime,
+) -> None:
+    manifest_bytes = _json_bytes(manifest) + b"\n"
+    with artifact_path.open("wb") as raw, gzip.GzipFile(
+        filename="", fileobj=raw, mode="wb", mtime=int(created_at.timestamp())
+    ) as compressed:
+        with tarfile.open(fileobj=compressed, mode="w", format=tarfile.USTAR_FORMAT) as archive:
+            info = tarfile.TarInfo("manifest.json")
+            info.size = len(manifest_bytes)
+            info.mtime = int(created_at.timestamp())
+            info.mode = 0o644
+            import io
+
+            archive.addfile(info, io.BytesIO(manifest_bytes))
+            info = tarfile.TarInfo("items.ndjson")
+            info.size = items_path.stat().st_size
+            info.mtime = int(created_at.timestamp())
+            info.mode = 0o644
+            with items_path.open("rb") as items:
+                archive.addfile(info, items)
+            if permissions_path is not None:
+                info = tarfile.TarInfo("permissions.ndjson")
+                info.size = permissions_path.stat().st_size
+                info.mtime = int(created_at.timestamp())
+                info.mode = 0o644
+                with permissions_path.open("rb") as permissions:
+                    archive.addfile(info, permissions)
+
+
+def create_snapshot_artifact(
+    snapshot_format: str,
+    requested_by: str,
+    instance: str,
+    *,
+    include_permissions: bool = False,
+) -> SnapshotArtifact:
+    temporary_directory = tempfile.TemporaryDirectory(dir=settings.MREG_SNAPSHOT_TMPDIR)
+    directory = Path(temporary_directory.name)
+    created_at = datetime.now(timezone.utc).replace(microsecond=0)
+    items_path = directory / "items.ndjson"
+    permissions_path = directory / "permissions.ndjson" if include_permissions else None
+    try:
+        count, items_sha256, permission_count, permission_sha256, database_timestamp = _write_snapshot_data(
+            items_path,
+            permissions_path,
+            settings.MREG_SNAPSHOT_CHUNK_SIZE,
+        )
+        if count == 0:
+            raise SnapshotError("The source contains no snapshot items")
+        timestamp = created_at.strftime("%Y%m%dT%H%M%SZ")
+        if snapshot_format == ARCHIVE_FORMAT:
+            artifact_path = directory / f"mreg-snapshot-{timestamp}-v1.tar.gz"
+            manifest = {
+                "format": "no.uio.mreg.snapshot",
+                "format_version": 1,
+                "created_at": created_at.isoformat().replace("+00:00", "Z"),
+                "source": {"product": "django-mreg", "version": __version__, "instance": instance},
+                "snapshot": {
+                    "consistent": True,
+                    "database_timestamp": database_timestamp.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
+                },
+                "items": {"path": "items.ndjson", "count": count, "sha256": items_sha256},
+                "permissions": (
+                    {
+                        "path": "permissions.ndjson",
+                        "count": permission_count,
+                        "sha256": permission_sha256,
+                    }
+                    if include_permissions
+                    else None
+                ),
+                "semantics": {
+                    "dependency_ordered": True,
+                    "generated_records_omitted": [
+                        "A_from_ip_assignment",
+                        "AAAA_from_ip_assignment",
+                        "PTR_from_ip_assignment",
+                        "NS_from_zone",
+                    ],
+                    "audit_included": False,
+                    "permissions_included": include_permissions,
+                    "redacted": False,
+                },
+            }
+            _build_archive(items_path, permissions_path, artifact_path, manifest, created_at)
+            content_type = ARCHIVE_MEDIA_TYPE
+        else:
+            artifact_path = directory / f"mreg-import-{timestamp}-v1.json.gz"
+            _build_json_artifact(items_path, artifact_path, requested_by, created_at)
+            content_type = JSON_MEDIA_TYPE
+        digest = hashlib.sha256()
+        with artifact_path.open("rb") as artifact:
+            while chunk := artifact.read(1024 * 1024):
+                digest.update(chunk)
+        digest_bytes = digest.digest()
+        return SnapshotArtifact(
+            path=artifact_path,
+            temporary_directory=temporary_directory,
+            digest_hex=digest.hexdigest(),
+            digest_base64=base64.b64encode(digest_bytes).decode("ascii"),
+            filename=artifact_path.name,
+            content_type=content_type,
+        )
+    except Exception:
+        temporary_directory.cleanup()
+        raise
+
+
+class SnapshotFileResponse(FileResponse):
+    def __init__(self, artifact: SnapshotArtifact):
+        self.artifact = artifact
+        super().__init__(artifact.path.open("rb"), as_attachment=True, filename=artifact.filename, content_type=artifact.content_type)
+
+    def close(self):
+        try:
+            super().close()
+        finally:
+            self.artifact.temporary_directory.cleanup()
+
+
+def _error_response(code: str, message: str, status_code: int, error: SnapshotError | None = None) -> Response:
+    body: dict[str, Any] = {"error": code, "message": message}
+    if error and error.model is not None:
+        body["source"] = {"model": error.model, "id": error.object_id}
+    return Response(body, status=status_code)
+
+
+def _header_allows(header: str, value: str) -> bool:
+    """Return whether a simple weighted HTTP capability header permits value."""
+    value_type = value.split("/", 1)[0] if "/" in value else None
+    for entry in header.lower().split(","):
+        parts = [part.strip() for part in entry.split(";")]
+        candidate = parts[0]
+        quality = 1.0
+        for parameter in parts[1:]:
+            if parameter.startswith("q="):
+                try:
+                    quality = float(parameter[2:])
+                except ValueError:
+                    quality = 0
+        if quality <= 0:
+            continue
+        if candidate in {"*", "*/*", value.lower()}:
+            return True
+        if value_type and candidate == f"{value_type}/*":
+            return True
+    return False
+
+
+def _parse_request(request) -> SnapshotOptions:
+    allowed = {"format", "include_permissions", *SUPPORTED_OPTIONS}
+    unknown = set(request.query_params) - allowed
+    if unknown:
+        raise SnapshotRequestError(f"Unsupported query parameter: {sorted(unknown)[0]}")
+    for key in allowed:
+        if len(request.query_params.getlist(key)) > 1:
+            raise SnapshotRequestError(f"Query parameter {key!r} may only be supplied once")
+    snapshot_format = request.query_params.get("format", ARCHIVE_FORMAT)
+    if snapshot_format not in {ARCHIVE_FORMAT, JSON_FORMAT}:
+        raise SnapshotRequestError(f"Unsupported snapshot format: {snapshot_format}")
+    include_permissions_value = request.query_params.get("include_permissions", "false")
+    if include_permissions_value not in {"false", "true"}:
+        raise SnapshotRequestError("Option 'include_permissions' must be 'true' or 'false'")
+    include_permissions = include_permissions_value == "true"
+    if include_permissions and snapshot_format != ARCHIVE_FORMAT:
+        raise SnapshotRequestError(
+            "Option 'include_permissions=true' is only supported by mreg-snapshot-v1"
+        )
+    for key, expected in SUPPORTED_OPTIONS.items():
+        actual = request.query_params.get(key, expected)
+        if actual != expected:
+            raise SnapshotRequestError(f"Option {key!r} only supports {expected!r} in version 1")
+    media_type = ARCHIVE_MEDIA_TYPE if snapshot_format == ARCHIVE_FORMAT else JSON_MEDIA_TYPE
+    accept = request.headers.get("Accept", "*/*")
+    if not _header_allows(accept, media_type):
+        raise SnapshotNotAcceptable(f"The requested format requires Accept: {media_type}")
+    accept_encoding = request.headers.get("Accept-Encoding", "")
+    if accept_encoding and not _header_allows(accept_encoding, "gzip"):
+        raise SnapshotNotAcceptable("The snapshot requires gzip content encoding")
+    return SnapshotOptions(snapshot_format=snapshot_format, include_permissions=include_permissions)
+
+
+class SnapshotView(APIView):
+    permission_classes = (IsAuthenticated,)
+
+    def get(self, request):
+        if not User.from_request(request).is_mreg_snapshotter:
+            return _error_response(
+                "snapshot_forbidden",
+                "The principal does not have snapshot permission",
+                403,
+            )
+        try:
+            options = _parse_request(request)
+            artifact = create_snapshot_artifact(
+                options.snapshot_format,
+                request.user.username,
+                request.get_host(),
+                include_permissions=options.include_permissions,
+            )
+        except SnapshotNotAcceptable as error:
+            return _error_response("snapshot_not_acceptable", str(error), 406, error)
+        except SnapshotRequestError as error:
+            return _error_response("invalid_snapshot_request", str(error), 400, error)
+        except SnapshotUnavailable as error:
+            return _error_response("snapshot_unavailable", str(error), 503, error)
+        except SnapshotError as error:
+            return _error_response("snapshot_failed", str(error), 409, error)
+        except OSError:
+            return _error_response("snapshot_unavailable", "The snapshot artifact could not be created", 503)
+
+        response = SnapshotFileResponse(artifact)
+        response["Content-Encoding"] = "gzip"
+        response["Digest"] = f"sha-256=:{artifact.digest_base64}:"
+        response["ETag"] = f'"snapshot-{artifact.digest_hex}"'
+        response["Cache-Control"] = "private, no-store"
+        response["X-Content-Type-Options"] = "nosniff"
+        return response

--- a/mreg/api/v1/snapshot.py
+++ b/mreg/api/v1/snapshot.py
@@ -18,6 +18,7 @@ from django.conf import settings
 from django.db import DatabaseError, connection, transaction
 from django.db.models import Count
 from django.http import FileResponse
+from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -53,6 +54,20 @@ SUPPORTED_OPTIONS = {
     "validate": "true",
     "redact": "false",
 }
+DEFERRED_WILDCARD_RECORD_TYPES = frozenset({"HINFO", "LOC", "SSHFP"})
+
+
+class SnapshotArchiveRenderer(JSONRenderer):
+    """Register the archive representation for DRF content negotiation."""
+
+    media_type = ARCHIVE_MEDIA_TYPE
+    format = ARCHIVE_FORMAT
+
+
+class SnapshotJSONRenderer(JSONRenderer):
+    """Register the compatibility representation's query format."""
+
+    format = JSON_FORMAT
 
 
 class SnapshotError(Exception):
@@ -94,7 +109,7 @@ def _normalized_mac(value: str) -> str | None:
     compact = "".join(character for character in value.lower() if character.isalnum())
     if len(compact) != 12:
         raise SnapshotError(f"Invalid MAC address {value!r}")
-    return ":".join(compact[index:index + 2] for index in range(0, 12, 2))
+    return ":".join(compact[index : index + 2] for index in range(0, 12, 2))
 
 
 class NetworkIndex:
@@ -192,9 +207,7 @@ def _network_zone_items(chunk_size: int) -> Iterator[dict[str, Any]]:
     communities = Community.objects.select_related("network__policy").order_by("pk")
     for obj in communities.iterator(chunk_size=chunk_size):
         if obj.network.policy_id is None:
-            raise SnapshotError(
-                "Community references a network without a policy", model="Community", object_id=obj.pk
-            )
+            raise SnapshotError("Community references a network without a policy", model="Community", object_id=obj.pk)
         yield _item(
             _ref("community", obj.pk),
             "community",
@@ -309,9 +322,7 @@ def _attachment_items(index: NetworkIndex, wildcards: set[int], chunk_size: int)
 
 
 def _ip_items(index: NetworkIndex, wildcards: set[int], chunk_size: int) -> Iterator[dict[str, Any]]:
-    duplicate = (
-        Ipaddress.objects.values("ipaddress").annotate(count=Count("pk")).filter(count__gt=1).order_by("ipaddress").first()
-    )
+    duplicate = Ipaddress.objects.values("ipaddress").annotate(count=Count("pk")).filter(count__gt=1).order_by("ipaddress").first()
     if duplicate:
         raise SnapshotError(f"IP address {duplicate['ipaddress']} is assigned more than once", model="Ipaddress")
     for obj in _ip_rows(chunk_size):
@@ -366,7 +377,7 @@ def _parse_loc(value: str, *, pk: Any) -> dict[str, float]:
                 result += numbers[2] / 3600
             return -result if direction in {"S", "W"} else result
 
-        remaining = [float(token.removesuffix("m")) for token in tokens[lon_end + 1:]]
+        remaining = [float(token.removesuffix("m")) for token in tokens[lon_end + 1 :]]
         if not remaining:
             raise ValueError("missing altitude")
         result = {
@@ -374,30 +385,51 @@ def _parse_loc(value: str, *, pk: Any) -> dict[str, float]:
             "longitude": coordinate(tokens[lon_start:lon_end], tokens[lon_end]),
             "altitude_m": remaining[0],
         }
-        for key, number in zip(
-            ("size_m", "horizontal_precision_m", "vertical_precision_m"), remaining[1:], strict=False
-        ):
+        for key, number in zip(("size_m", "horizontal_precision_m", "vertical_precision_m"), remaining[1:], strict=False):
             result[key] = number
         return result
     except (ValueError, IndexError) as error:
         raise SnapshotError("LOC value cannot be translated", model="Loc", object_id=pk) from error
 
 
-def _dns_record_items(wildcards: set[int], chunk_size: int) -> Iterator[dict[str, Any]]:
+def _split_dns_character_strings(value: str) -> list[str]:
+    """Split text into RFC 1035 character-strings of at most 255 octets."""
+    chunks: list[str] = []
+    current: list[str] = []
+    current_size = 0
+    for character in value:
+        character_size = len(character.encode("utf-8"))
+        if current and current_size + character_size > 255:
+            chunks.append("".join(current))
+            current = []
+            current_size = 0
+        current.append(character)
+        current_size += character_size
+    chunks.append("".join(current))
+    return chunks
+
+
+def _dns_record_items(
+    wildcards: set[int],
+    chunk_size: int,
+    *,
+    only_deferred: bool = False,
+) -> Iterator[dict[str, Any]]:
     wildcard_hosts = {pk: (name, ttl) for pk, name, ttl in Host.objects.filter(pk__in=wildcards).values_list("pk", "name", "ttl")}
-    for obj in Ipaddress.objects.filter(host_id__in=wildcards).select_related("host").order_by("pk").iterator(chunk_size=chunk_size):
-        address = ipaddress.ip_address(obj.ipaddress)
-        yield _item(
-            _ref("record_ip_address", obj.pk),
-            "record",
-            _record_attributes("A" if address.version == 4 else "AAAA", obj.host.name, {"address": obj.ipaddress}, ttl=obj.host.ttl),
-        )
+    if not only_deferred:
+        for obj in Ipaddress.objects.filter(host_id__in=wildcards).select_related("host").order_by("pk").iterator(chunk_size=chunk_size):
+            address = ipaddress.ip_address(obj.ipaddress)
+            yield _item(
+                _ref("record_ip_address", obj.pk),
+                "record",
+                _record_attributes("A" if address.version == 4 else "AAAA", obj.host.name, {"address": obj.ipaddress}, ttl=obj.host.ttl),
+            )
 
     specifications = (
         (Hinfo, "HINFO", lambda o: {"cpu": o.cpu, "os": o.os}, lambda o: o.host.ttl),
         (Loc, "LOC", lambda o: _parse_loc(o.loc, pk=o.pk), lambda o: o.host.ttl),
         (Mx, "MX", lambda o: {"preference": o.priority, "exchange": o.mx}, lambda o: o.host.ttl),
-        (Txt, "TXT", lambda o: {"value": o.txt}, lambda o: o.host.ttl),
+        (Txt, "TXT", lambda o: {"value": _split_dns_character_strings(o.txt)}, lambda o: o.host.ttl),
         (
             Naptr,
             "NAPTR",
@@ -422,6 +454,9 @@ def _dns_record_items(wildcards: set[int], chunk_size: int) -> Iterator[dict[str
         queryset = model.objects.select_related("host").order_by("pk")
         for obj in queryset.iterator(chunk_size=chunk_size):
             wildcard = obj.host_id in wildcards
+            deferred = wildcard and type_name in DEFERRED_WILDCARD_RECORD_TYPES
+            if deferred != only_deferred:
+                continue
             if type_name == "MX" and not wildcard:
                 owner_kind = "forward_zone"
                 anchor_ref = _ref("forward_zone", obj.host.zone_id) if obj.host.zone_id else None
@@ -430,7 +465,7 @@ def _dns_record_items(wildcards: set[int], chunk_size: int) -> Iterator[dict[str
             else:
                 owner_kind = None if wildcard else "host"
                 anchor_ref = None if wildcard else _ref("host", obj.host_id)
-            yield _item(
+            item = _item(
                 _ref(f"record_{model._meta.model_name}", obj.pk),
                 "record",
                 _record_attributes(
@@ -442,6 +477,15 @@ def _dns_record_items(wildcards: set[int], chunk_size: int) -> Iterator[dict[str
                     anchor_ref=anchor_ref,
                 ),
             )
+            if deferred:
+                item["deferred"] = {
+                    "reason": "wildcard_owner_not_supported_by_import_contract",
+                    "requires_manual_handling": True,
+                }
+            yield item
+    if only_deferred:
+        return
+
     for model, type_name, data_factory in (
         (Cname, "CNAME", lambda o: {"target": o.host.name}),
         (Srv, "SRV", lambda o: {"priority": o.priority, "weight": o.weight, "port": o.port, "target": o.host.name}),
@@ -507,9 +551,7 @@ def _relationship_items(index: NetworkIndex, wildcards: set[int], chunk_size: in
             raise SnapshotError("Community does not match the IP network", model="HostCommunityMapping", object_id=obj.pk)
         previous = seen.get(attachment)
         if previous is not None and previous != obj.community_id:
-            raise SnapshotError(
-                "One attachment maps to conflicting legacy communities", model="HostCommunityMapping", object_id=obj.pk
-            )
+            raise SnapshotError("One attachment maps to conflicting legacy communities", model="HostCommunityMapping", object_id=obj.pk)
         if previous is not None:
             continue
         seen[attachment] = obj.community_id
@@ -593,6 +635,11 @@ def iter_import_items(chunk_size: int) -> Iterator[dict[str, Any]]:
     yield from _host_policy_items(wildcards, chunk_size)
 
 
+def iter_deferred_record_items(chunk_size: int) -> Iterator[dict[str, Any]]:
+    """Yield valid source records whose automatic import must be deferred."""
+    yield from _dns_record_items(_wildcard_ids(), chunk_size, only_deferred=True)
+
+
 @dataclass
 class SnapshotArtifact:
     path: Path
@@ -643,9 +690,10 @@ def _write_ndjson(path: Path, values: Iterable[dict[str, Any]]) -> tuple[int, st
 
 def _write_snapshot_data(
     items_path: Path,
+    deferred_records_path: Path,
     permissions_path: Path | None,
     chunk_size: int,
-) -> tuple[int, str, int | None, str | None, datetime]:
+) -> tuple[int, str, int, str, int | None, str | None, datetime]:
     try:
         with transaction.atomic(), connection.cursor() as cursor:
             if connection.vendor != "postgresql":
@@ -654,48 +702,70 @@ def _write_snapshot_data(
             cursor.execute("SELECT transaction_timestamp()")
             database_timestamp = cursor.fetchone()[0]
             item_count, item_sha256 = _write_ndjson(items_path, iter_import_items(chunk_size))
+            deferred_count, deferred_sha256 = _write_ndjson(
+                deferred_records_path,
+                iter_deferred_record_items(chunk_size),
+            )
             if permissions_path is None:
                 permission_count = None
                 permission_sha256 = None
             else:
-                permission_count, permission_sha256 = _write_ndjson(
-                    permissions_path, iter_permission_items(chunk_size)
-                )
+                permission_count, permission_sha256 = _write_ndjson(permissions_path, iter_permission_items(chunk_size))
     except SnapshotError:
         raise
     except DatabaseError as error:
         raise SnapshotUnavailable("A consistent database snapshot could not be read") from error
-    return item_count, item_sha256, permission_count, permission_sha256, database_timestamp
+    return (
+        item_count,
+        item_sha256,
+        deferred_count,
+        deferred_sha256,
+        permission_count,
+        permission_sha256,
+        database_timestamp,
+    )
 
 
-def _build_json_artifact(items_path: Path, artifact_path: Path, requested_by: str, created_at: datetime) -> None:
-    with artifact_path.open("wb") as raw, gzip.GzipFile(
-        filename="", fileobj=raw, mode="wb", mtime=int(created_at.timestamp())
-    ) as output:
+def _write_json_array(output, path: Path) -> None:
+    first = True
+    with path.open("rb") as values:
+        for line in values:
+            if not first:
+                output.write(b",")
+            output.write(line.rstrip(b"\n"))
+            first = False
+
+
+def _build_json_artifact(
+    items_path: Path,
+    deferred_records_path: Path,
+    artifact_path: Path,
+    requested_by: str,
+    created_at: datetime,
+) -> None:
+    with artifact_path.open("wb") as raw, gzip.GzipFile(filename="", fileobj=raw, mode="wb", mtime=int(created_at.timestamp())) as output:
         output.write(b'{"requested_by":')
         output.write(_json_bytes(requested_by))
         output.write(b',"items":[')
-        first = True
-        with items_path.open("rb") as items:
-            for line in items:
-                if not first:
-                    output.write(b",")
-                output.write(line.rstrip(b"\n"))
-                first = False
+        _write_json_array(output, items_path)
+        output.write(b'],"deferred_records":[')
+        _write_json_array(output, deferred_records_path)
         output.write(b"]}\n")
 
 
 def _build_archive(
     items_path: Path,
+    deferred_records_path: Path,
     permissions_path: Path | None,
     artifact_path: Path,
     manifest: dict[str, Any],
     created_at: datetime,
 ) -> None:
     manifest_bytes = _json_bytes(manifest) + b"\n"
-    with artifact_path.open("wb") as raw, gzip.GzipFile(
-        filename="", fileobj=raw, mode="wb", mtime=int(created_at.timestamp())
-    ) as compressed:
+    with (
+        artifact_path.open("wb") as raw,
+        gzip.GzipFile(filename="", fileobj=raw, mode="wb", mtime=int(created_at.timestamp())) as compressed,
+    ):
         with tarfile.open(fileobj=compressed, mode="w", format=tarfile.USTAR_FORMAT) as archive:
             info = tarfile.TarInfo("manifest.json")
             info.size = len(manifest_bytes)
@@ -710,6 +780,12 @@ def _build_archive(
             info.mode = 0o644
             with items_path.open("rb") as items:
                 archive.addfile(info, items)
+            info = tarfile.TarInfo("deferred-records.ndjson")
+            info.size = deferred_records_path.stat().st_size
+            info.mtime = int(created_at.timestamp())
+            info.mode = 0o644
+            with deferred_records_path.open("rb") as deferred_records:
+                archive.addfile(info, deferred_records)
             if permissions_path is not None:
                 info = tarfile.TarInfo("permissions.ndjson")
                 info.size = permissions_path.stat().st_size
@@ -730,10 +806,20 @@ def create_snapshot_artifact(
     directory = Path(temporary_directory.name)
     created_at = datetime.now(timezone.utc).replace(microsecond=0)
     items_path = directory / "items.ndjson"
+    deferred_records_path = directory / "deferred-records.ndjson"
     permissions_path = directory / "permissions.ndjson" if include_permissions else None
     try:
-        count, items_sha256, permission_count, permission_sha256, database_timestamp = _write_snapshot_data(
+        (
+            count,
+            items_sha256,
+            deferred_count,
+            deferred_sha256,
+            permission_count,
+            permission_sha256,
+            database_timestamp,
+        ) = _write_snapshot_data(
             items_path,
+            deferred_records_path,
             permissions_path,
             settings.MREG_SNAPSHOT_CHUNK_SIZE,
         )
@@ -752,6 +838,11 @@ def create_snapshot_artifact(
                     "database_timestamp": database_timestamp.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
                 },
                 "items": {"path": "items.ndjson", "count": count, "sha256": items_sha256},
+                "deferred_records": {
+                    "path": "deferred-records.ndjson",
+                    "count": deferred_count,
+                    "sha256": deferred_sha256,
+                },
                 "permissions": (
                     {
                         "path": "permissions.ndjson",
@@ -772,13 +863,27 @@ def create_snapshot_artifact(
                     "audit_included": False,
                     "permissions_included": include_permissions,
                     "redacted": False,
+                    "fully_importable": deferred_count == 0,
                 },
             }
-            _build_archive(items_path, permissions_path, artifact_path, manifest, created_at)
+            _build_archive(
+                items_path,
+                deferred_records_path,
+                permissions_path,
+                artifact_path,
+                manifest,
+                created_at,
+            )
             content_type = ARCHIVE_MEDIA_TYPE
         else:
             artifact_path = directory / f"mreg-import-{timestamp}-v1.json.gz"
-            _build_json_artifact(items_path, artifact_path, requested_by, created_at)
+            _build_json_artifact(
+                items_path,
+                deferred_records_path,
+                artifact_path,
+                requested_by,
+                created_at,
+            )
             content_type = JSON_MEDIA_TYPE
         digest = hashlib.sha256()
         with artifact_path.open("rb") as artifact:
@@ -814,12 +919,13 @@ def _error_response(code: str, message: str, status_code: int, error: SnapshotEr
     body: dict[str, Any] = {"error": code, "message": message}
     if error and error.model is not None:
         body["source"] = {"model": error.model, "id": error.object_id}
-    return Response(body, status=status_code)
+    return Response(body, status=status_code, content_type=JSON_MEDIA_TYPE)
 
 
 def _header_allows(header: str, value: str) -> bool:
-    """Return whether a simple weighted HTTP capability header permits value."""
+    """Return whether the most specific HTTP capability range permits value."""
     value_type = value.split("/", 1)[0] if "/" in value else None
+    matches: list[tuple[int, float]] = []
     for entry in header.lower().split(","):
         parts = [part.strip() for part in entry.split(";")]
         candidate = parts[0]
@@ -830,13 +936,18 @@ def _header_allows(header: str, value: str) -> bool:
                     quality = float(parameter[2:])
                 except ValueError:
                     quality = 0
-        if quality <= 0:
-            continue
-        if candidate in {"*", "*/*", value.lower()}:
-            return True
-        if value_type and candidate == f"{value_type}/*":
-            return True
-    return False
+        if not 0 <= quality <= 1:
+            quality = 0
+        if candidate == value.lower():
+            matches.append((2, quality))
+        elif value_type and candidate == f"{value_type}/*":
+            matches.append((1, quality))
+        elif candidate in {"*", "*/*"}:
+            matches.append((0, quality))
+    if not matches:
+        return False
+    specificity = max(match[0] for match in matches)
+    return max(quality for match_specificity, quality in matches if match_specificity == specificity) > 0
 
 
 def _parse_request(request) -> SnapshotOptions:
@@ -855,9 +966,7 @@ def _parse_request(request) -> SnapshotOptions:
         raise SnapshotRequestError("Option 'include_permissions' must be 'true' or 'false'")
     include_permissions = include_permissions_value == "true"
     if include_permissions and snapshot_format != ARCHIVE_FORMAT:
-        raise SnapshotRequestError(
-            "Option 'include_permissions=true' is only supported by mreg-snapshot-v1"
-        )
+        raise SnapshotRequestError("Option 'include_permissions=true' is only supported by mreg-snapshot-v1")
     for key, expected in SUPPORTED_OPTIONS.items():
         actual = request.query_params.get(key, expected)
         if actual != expected:
@@ -874,6 +983,7 @@ def _parse_request(request) -> SnapshotOptions:
 
 class SnapshotView(APIView):
     permission_classes = (IsAuthenticated,)
+    renderer_classes = (SnapshotArchiveRenderer, SnapshotJSONRenderer)
 
     def get(self, request):
         if not User.from_request(request).is_mreg_snapshotter:
@@ -903,7 +1013,7 @@ class SnapshotView(APIView):
 
         response = SnapshotFileResponse(artifact)
         response["Content-Encoding"] = "gzip"
-        response["Digest"] = f"sha-256=:{artifact.digest_base64}:"
+        response["Content-Digest"] = f"sha-256=:{artifact.digest_base64}:"
         response["ETag"] = f'"snapshot-{artifact.digest_hex}"'
         response["Cache-Control"] = "private, no-store"
         response["X-Content-Type-Options"] = "nosniff"

--- a/mreg/api/v1/snapshot.py
+++ b/mreg/api/v1/snapshot.py
@@ -66,7 +66,7 @@ class SnapshotArchiveRenderer(JSONRenderer):
 
 
 class SnapshotJSONRenderer(JSONRenderer):
-    """Register the compatibility representation's query format."""
+    """Register the JSON import representation's query format."""
 
     format = JSON_FORMAT
 

--- a/mreg/api/v1/tests/test_snapshot.py
+++ b/mreg/api/v1/tests/test_snapshot.py
@@ -19,7 +19,9 @@ from mreg.api.v1.snapshot import (
     SnapshotView,
     _parse_loc,
     _parse_request,
+    _split_dns_character_strings,
     create_snapshot_artifact,
+    iter_deferred_record_items,
     iter_import_items,
     iter_permission_items,
 )
@@ -72,6 +74,23 @@ PERMISSIONS = [
     }
 ]
 
+DEFERRED_RECORDS = [
+    {
+        "ref": "record_hinfo:9",
+        "kind": "record",
+        "operation": "create",
+        "attributes": {
+            "type_name": "HINFO",
+            "owner_name": "*.example.org",
+            "data": {"cpu": "x86_64", "os": "Linux"},
+        },
+        "deferred": {
+            "reason": "wildcard_owner_not_supported_by_import_contract",
+            "requires_manual_handling": True,
+        },
+    }
+]
+
 
 def write_values(path, values):
     digest = hashlib.sha256()
@@ -83,8 +102,12 @@ def write_values(path, values):
     return len(values), digest.hexdigest()
 
 
-def fake_write_snapshot_data(items_path, permissions_path, chunk_size):
+def fake_write_snapshot_data(items_path, deferred_records_path, permissions_path, chunk_size):
     item_count, item_sha256 = write_values(items_path, ITEMS)
+    deferred_count, deferred_sha256 = write_values(
+        deferred_records_path,
+        DEFERRED_RECORDS,
+    )
     if permissions_path is None:
         permission_count, permission_sha256 = None, None
     else:
@@ -92,6 +115,8 @@ def fake_write_snapshot_data(items_path, permissions_path, chunk_size):
     return (
         item_count,
         item_sha256,
+        deferred_count,
+        deferred_sha256,
         permission_count,
         permission_sha256,
         datetime(2026, 7, 12, 10, 14, 58, tzinfo=timezone.utc),
@@ -107,15 +132,29 @@ class SnapshotArtifactTests(SimpleTestCase):
             compressed = artifact.path.read_bytes()
             self.assertEqual(hashlib.sha256(compressed).hexdigest(), artifact.digest_hex)
             with tarfile.open(fileobj=io.BytesIO(compressed), mode="r:gz") as archive:
-                self.assertEqual(archive.getnames(), ["manifest.json", "items.ndjson"])
+                self.assertEqual(
+                    archive.getnames(),
+                    ["manifest.json", "items.ndjson", "deferred-records.ndjson"],
+                )
                 manifest = json.load(archive.extractfile("manifest.json"))
                 item_bytes = archive.extractfile("items.ndjson").read()
+                deferred_bytes = archive.extractfile("deferred-records.ndjson").read()
             self.assertEqual(manifest["format"], "no.uio.mreg.snapshot")
             self.assertEqual(manifest["format_version"], 1)
             self.assertTrue(manifest["snapshot"]["consistent"])
             self.assertEqual(manifest["items"]["count"], 2)
             self.assertEqual(manifest["items"]["sha256"], hashlib.sha256(item_bytes).hexdigest())
+            self.assertFalse(manifest["semantics"]["fully_importable"])
+            self.assertEqual(manifest["deferred_records"]["count"], 1)
+            self.assertEqual(
+                manifest["deferred_records"]["sha256"],
+                hashlib.sha256(deferred_bytes).hexdigest(),
+            )
             self.assertEqual([json.loads(line) for line in item_bytes.splitlines()], ITEMS)
+            self.assertEqual(
+                [json.loads(line) for line in deferred_bytes.splitlines()],
+                DEFERRED_RECORDS,
+            )
         finally:
             artifact.temporary_directory.cleanup()
 
@@ -125,7 +164,14 @@ class SnapshotArtifactTests(SimpleTestCase):
         try:
             with gzip.open(artifact.path, "rt", encoding="utf-8") as source:
                 document = json.load(source)
-            self.assertEqual(document, {"requested_by": "snapshotter", "items": ITEMS})
+            self.assertEqual(
+                document,
+                {
+                    "requested_by": "snapshotter",
+                    "items": ITEMS,
+                    "deferred_records": DEFERRED_RECORDS,
+                },
+            )
         finally:
             artifact.temporary_directory.cleanup()
 
@@ -141,7 +187,12 @@ class SnapshotArtifactTests(SimpleTestCase):
             with tarfile.open(artifact.path, mode="r:gz") as archive:
                 self.assertEqual(
                     archive.getnames(),
-                    ["manifest.json", "items.ndjson", "permissions.ndjson"],
+                    [
+                        "manifest.json",
+                        "items.ndjson",
+                        "deferred-records.ndjson",
+                        "permissions.ndjson",
+                    ],
                 )
                 manifest = json.load(archive.extractfile("manifest.json"))
                 permission_bytes = archive.extractfile("permissions.ndjson").read()
@@ -164,6 +215,11 @@ class SnapshotArtifactTests(SimpleTestCase):
         self.assertAlmostEqual(value["longitude"], -71.105)
         self.assertEqual(value["altitude_m"], -24)
         self.assertEqual(value["size_m"], 30)
+
+    def test_txt_values_are_split_by_encoded_octets(self):
+        chunks = _split_dns_character_strings("a" * 510 + "ø" * 128)
+        self.assertEqual("".join(chunks), "a" * 510 + "ø" * 128)
+        self.assertTrue(all(len(chunk.encode("utf-8")) <= 255 for chunk in chunks))
 
 
 class SnapshotRequestTests(SimpleTestCase):
@@ -189,9 +245,7 @@ class SnapshotRequestTests(SimpleTestCase):
         self.assertFalse(options.include_permissions)
 
     def test_accepts_permissions_for_archive(self):
-        options = _parse_request(
-            self.request("/api/v1/snapshot?include_permissions=true")
-        )
+        options = _parse_request(self.request("/api/v1/snapshot?include_permissions=true"))
         self.assertTrue(options.include_permissions)
 
     def test_rejects_non_default_options(self):
@@ -199,18 +253,22 @@ class SnapshotRequestTests(SimpleTestCase):
             _parse_request(self.request("/api/v1/snapshot?include_audit=true"))
 
     def test_rejects_explicitly_disabled_gzip(self):
+        for header in ("br, gzip;q=0", "gzip;q=0, *;q=1"):
+            with self.subTest(header=header), self.assertRaises(SnapshotRequestError):
+                _parse_request(self.request("/api/v1/snapshot", HTTP_ACCEPT_ENCODING=header))
+
+    def test_rejects_explicitly_disabled_media_type(self):
         with self.assertRaises(SnapshotRequestError):
             _parse_request(
-                self.request("/api/v1/snapshot", HTTP_ACCEPT_ENCODING="br, gzip;q=0")
+                self.request(
+                    "/api/v1/snapshot",
+                    HTTP_ACCEPT="application/vnd.uio.mreg-snapshot+tar;q=0, */*;q=1",
+                )
             )
 
     def test_rejects_permissions_for_compatibility_json(self):
         with self.assertRaises(SnapshotRequestError):
-            _parse_request(
-                self.request(
-                    "/api/v1/snapshot?format=mreg-import-json-v1&include_permissions=true"
-                )
-            )
+            _parse_request(self.request("/api/v1/snapshot?format=mreg-import-json-v1&include_permissions=true"))
 
     def test_rejects_duplicate_and_unknown_parameters(self):
         for path in (
@@ -226,8 +284,8 @@ class SnapshotViewTests(SimpleTestCase):
     def setUp(self):
         self.factory = APIRequestFactory()
 
-    def request(self, *, allowed):
-        request = self.factory.get("/api/v1/snapshot")
+    def request(self, *, allowed, path="/api/v1/snapshot", **headers):
+        request = self.factory.get(path, **headers)
         user = SimpleNamespace(
             is_authenticated=True,
             is_mreg_snapshotter=allowed,
@@ -243,17 +301,38 @@ class SnapshotViewTests(SimpleTestCase):
 
     @mock.patch("mreg.api.v1.snapshot._write_snapshot_data", side_effect=fake_write_snapshot_data)
     def test_response_headers_and_cleanup(self, _write_snapshot_data):
-        response = SnapshotView.as_view()(self.request(allowed=True))
+        response = SnapshotView.as_view()(
+            self.request(
+                allowed=True,
+                HTTP_ACCEPT="application/vnd.uio.mreg-snapshot+tar",
+                HTTP_ACCEPT_ENCODING="gzip",
+            )
+        )
         artifact_path = response.artifact.path
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["Content-Encoding"], "gzip")
-        self.assertTrue(response["Digest"].startswith("sha-256=:"))
+        self.assertTrue(response["Content-Digest"].startswith("sha-256=:"))
+        self.assertNotIn("Digest", response)
         self.assertTrue(response["ETag"].startswith('"snapshot-'))
         self.assertEqual(response["Cache-Control"], "private, no-store")
         self.assertTrue(artifact_path.exists())
         b"".join(response.streaming_content)
         response.close()
         self.assertFalse(artifact_path.exists())
+
+    @mock.patch("mreg.api.v1.snapshot._write_snapshot_data", side_effect=fake_write_snapshot_data)
+    def test_compatibility_media_type_is_negotiated(self, _write_snapshot_data):
+        response = SnapshotView.as_view()(
+            self.request(
+                allowed=True,
+                path="/api/v1/snapshot?format=mreg-import-json-v1",
+                HTTP_ACCEPT="application/json",
+                HTTP_ACCEPT_ENCODING="gzip",
+            )
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/json")
+        response.close()
 
 
 class SnapshotItemTranslationTests(TestCase):
@@ -270,10 +349,8 @@ class SnapshotItemTranslationTests(TestCase):
         )
         permission.labels.add(cls.label)
 
-        cls.attribute = NetworkPolicyAttribute.objects.create(name="isolated", description="Isolation")
-        cls.policy = NetworkPolicy.objects.create(
-            name="campus", description="Campus policy", community_template_pattern="community"
-        )
+        cls.attribute = NetworkPolicyAttribute.objects.get(name="isolated")
+        cls.policy = NetworkPolicy.objects.create(name="campus", description="Campus policy", community_template_pattern="community")
         NetworkPolicyAttributeValue.objects.create(policy=cls.policy, attribute=cls.attribute, value=True)
         cls.network = Network.objects.create(
             network="192.0.2.0/24",
@@ -301,9 +378,7 @@ class SnapshotItemTranslationTests(TestCase):
             email="hostmaster@example.org",
         )
         cls.reverse_zone.nameservers.add(cls.nameserver)
-        forward_delegation = ForwardZoneDelegation.objects.create(
-            zone=cls.forward_zone, name="delegated.example.org", comment="Delegated"
-        )
+        forward_delegation = ForwardZoneDelegation.objects.create(zone=cls.forward_zone, name="delegated.example.org", comment="Delegated")
         forward_delegation.nameservers.add(cls.nameserver)
         reverse_delegation = ReverseZoneDelegation.objects.create(
             zone=cls.reverse_zone, name="128-25.2.0.192.in-addr.arpa", comment="Delegated"
@@ -315,7 +390,8 @@ class SnapshotItemTranslationTests(TestCase):
         Hinfo.objects.create(host=cls.host, cpu="x86_64", os="Linux")
         Loc.objects.create(host=cls.host, loc="59 54 0 N 10 42 0 E 50m 1m 2m 3m")
         Mx.objects.create(host=cls.host, priority=10, mx="mail.example.org")
-        Txt.objects.create(host=cls.host, txt="v=spf1 -all")
+        Txt.objects.get_or_create(host=cls.host, txt="v=spf1 -all")
+        cls.long_txt = Txt.objects.create(host=cls.host, txt="k" * 600)
         Naptr.objects.create(
             host=cls.host,
             order=100,
@@ -364,6 +440,14 @@ class SnapshotItemTranslationTests(TestCase):
         wildcard = Host.objects.create(name="*.wild.example.org", zone=cls.forward_zone, ttl=120)
         Ipaddress.objects.create(host=wildcard, ipaddress="192.0.2.99")
         Txt.objects.create(host=wildcard, txt="wildcard")
+        Hinfo.objects.create(host=wildcard, cpu="x86_64", os="Linux")
+        Loc.objects.create(host=wildcard, loc="59 54 0 N 10 42 0 E 50m")
+        Sshfp.objects.create(
+            host=wildcard,
+            algorithm=4,
+            hash_type=2,
+            fingerprint="b" * 64,
+        )
 
     def test_dependency_ordered_translation_covers_supported_legacy_models(self):
         items = list(iter_import_items(10))
@@ -405,10 +489,24 @@ class SnapshotItemTranslationTests(TestCase):
         address = next(item for item in items if item["kind"] == "ip_address")
         self.assertLess(positions[attachment["ref"]], positions[address["ref"]])
         self.assertEqual(address["attributes"]["attachment_id_ref"], attachment["ref"])
-        wildcard_records = [
-            item for item in items if item["kind"] == "record" and item["attributes"]["owner_name"] == "*.wild.example.org"
-        ]
+        wildcard_records = [item for item in items if item["kind"] == "record" and item["attributes"]["owner_name"] == "*.wild.example.org"]
         self.assertEqual({item["attributes"]["type_name"] for item in wildcard_records}, {"A", "TXT"})
+        wildcard_txt_values = {
+            tuple(item["attributes"]["data"]["value"]) for item in wildcard_records if item["attributes"]["type_name"] == "TXT"
+        }
+        self.assertIn(("wildcard",), wildcard_txt_values)
+        long_txt_record = next(item for item in items if item["ref"] == f"record_txt:{self.long_txt.pk}")
+        self.assertEqual(
+            [len(chunk.encode("utf-8")) for chunk in long_txt_record["attributes"]["data"]["value"]],
+            [255, 255, 90],
+        )
+
+        deferred_records = list(iter_deferred_record_items(10))
+        self.assertEqual(
+            {item["attributes"]["type_name"] for item in deferred_records},
+            {"HINFO", "LOC", "SSHFP"},
+        )
+        self.assertTrue(all(item["deferred"]["requires_manual_handling"] for item in deferred_records))
 
         permissions = list(iter_permission_items(10))
         self.assertEqual(

--- a/mreg/api/v1/tests/test_snapshot.py
+++ b/mreg/api/v1/tests/test_snapshot.py
@@ -3,25 +3,44 @@ import hashlib
 import io
 import json
 import tarfile
+import tempfile
+from contextlib import nullcontext
 from datetime import datetime, timezone
+from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
 from django.contrib.auth.models import Group
+from django.db import DatabaseError
 from django.test import SimpleTestCase, TestCase, override_settings
 from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory, force_authenticate
+from unittest_parametrize import ParametrizedTestCase, param, parametrize
 
 from mreg.api.v1.snapshot import (
     ARCHIVE_FORMAT,
     JSON_FORMAT,
+    NetworkIndex,
+    SnapshotArtifact,
     SnapshotData,
     SnapshotDataFile,
+    SnapshotError,
+    SnapshotFileResponse,
+    SnapshotNotAcceptable,
     SnapshotRequestError,
+    SnapshotUnavailable,
     SnapshotView,
+    _attachment_items,
+    _header_allows,
+    _host_dns_record_items,
+    _host_group_items,
+    _ip_items,
+    _normalized_mac,
     _parse_loc,
     _parse_request,
     _split_dns_character_strings,
+    _validate_wildcard_hosts,
+    _write_snapshot_data,
     create_snapshot_artifact,
     iter_deferred_record_items,
     iter_import_items,
@@ -120,7 +139,7 @@ def fake_write_snapshot_data(directory, chunk_size, *, include_permissions):
 
 
 @override_settings(MREG_SNAPSHOT_TMPDIR=None, MREG_SNAPSHOT_CHUNK_SIZE=10)
-class SnapshotArtifactTests(SimpleTestCase):
+class SnapshotArtifactTests(ParametrizedTestCase, SimpleTestCase):
     @mock.patch("mreg.api.v1.snapshot._write_snapshot_data", side_effect=fake_write_snapshot_data)
     def test_archive_contract(self, _write_snapshot_data):
         artifact = create_snapshot_artifact(ARCHIVE_FORMAT, "snapshotter", "mreg.example.org")
@@ -205,20 +224,51 @@ class SnapshotArtifactTests(SimpleTestCase):
         finally:
             artifact.cleanup()
 
-    def test_rejects_invalid_direct_options(self):
-        invalid_options = (
-            ("unsupported", False),
-            (JSON_FORMAT, True),
+    @parametrize(
+        ("snapshot_format", "include_permissions"),
+        [
+            param("unsupported", False, id="unsupported_format"),
+            param(JSON_FORMAT, True, id="json_with_permissions"),
+        ],
+    )
+    def test_rejects_invalid_direct_options(self, snapshot_format, include_permissions):
+        with self.assertRaises(SnapshotRequestError):
+            create_snapshot_artifact(
+                snapshot_format,
+                "snapshotter",
+                "mreg.example.org",
+                include_permissions=include_permissions,
+            )
+
+    @mock.patch("mreg.api.v1.snapshot._write_snapshot_data")
+    def test_rejects_empty_snapshot_data(self, write_snapshot_data):
+        empty_file = SnapshotDataFile(path=Path("items.ndjson"), count=0, sha256=hashlib.sha256().hexdigest())
+        write_snapshot_data.return_value = SnapshotData(
+            items=empty_file,
+            deferred_records=empty_file,
+            permissions=None,
+            database_timestamp=datetime(2026, 7, 12, 10, 14, 58, tzinfo=timezone.utc),
         )
-        for snapshot_format, include_permissions in invalid_options:
-            with self.subTest(snapshot_format=snapshot_format, include_permissions=include_permissions):
-                with self.assertRaises(SnapshotRequestError):
-                    create_snapshot_artifact(
-                        snapshot_format,
-                        "snapshotter",
-                        "mreg.example.org",
-                        include_permissions=include_permissions,
-                    )
+
+        with self.assertRaisesMessage(SnapshotError, "contains no snapshot items"):
+            create_snapshot_artifact(ARCHIVE_FORMAT, "snapshotter", "mreg.example.org")
+
+    def test_file_response_cleans_up_if_initialization_fails(self):
+        with tempfile.TemporaryDirectory() as directory:
+            artifact_path = Path(directory) / "snapshot.tar.gz"
+            artifact_path.write_bytes(b"snapshot")
+            artifact = mock.Mock(spec=SnapshotArtifact)
+            artifact.path = artifact_path
+            artifact.filename = artifact_path.name
+            artifact.content_type = "application/octet-stream"
+
+            with (
+                mock.patch("mreg.api.v1.snapshot.FileResponse.__init__", side_effect=RuntimeError("response failed")),
+                self.assertRaisesMessage(RuntimeError, "response failed"),
+            ):
+                SnapshotFileResponse(artifact)
+
+            artifact.cleanup.assert_called_once_with()
 
     def test_loc_conversion(self):
         value = _parse_loc("42 21 54 N 71 06 18 W -24m 30m", pk=1)
@@ -227,13 +277,201 @@ class SnapshotArtifactTests(SimpleTestCase):
         self.assertEqual(value["altitude_m"], -24)
         self.assertEqual(value["size_m"], 30)
 
+    def test_loc_conversion_rejects_incomplete_values(self):
+        with self.assertRaisesMessage(SnapshotError, "LOC value cannot be translated"):
+            _parse_loc("42 N 71 W", pk=7)
+
+    def test_mac_normalization_handles_empty_and_invalid_values(self):
+        self.assertIsNone(_normalized_mac(""))
+        with self.assertRaisesMessage(SnapshotError, "Invalid MAC address"):
+            _normalized_mac("not-a-mac")
+
     def test_txt_values_are_split_by_encoded_octets(self):
         chunks = _split_dns_character_strings("a" * 510 + "ø" * 128)
         self.assertEqual("".join(chunks), "a" * 510 + "ø" * 128)
         self.assertTrue(all(len(chunk.encode("utf-8")) <= 255 for chunk in chunks))
 
 
-class SnapshotRequestTests(SimpleTestCase):
+class SnapshotDataWritingTests(SimpleTestCase):
+    def fake_connection(self, *, vendor="postgresql", execute_error=None):
+        cursor = mock.MagicMock()
+        cursor.fetchone.return_value = (datetime(2026, 7, 12, 10, 14, 58, tzinfo=timezone.utc),)
+        if execute_error is not None:
+            cursor.execute.side_effect = execute_error
+        cursor_manager = mock.MagicMock()
+        cursor_manager.__enter__.return_value = cursor
+        connection = SimpleNamespace(vendor=vendor, cursor=mock.Mock(return_value=cursor_manager))
+        return connection, cursor
+
+    def test_writes_snapshot_data_and_metadata(self):
+        connection, cursor = self.fake_connection()
+        with (
+            tempfile.TemporaryDirectory() as directory,
+            mock.patch("mreg.api.v1.snapshot.connection", connection),
+            mock.patch("mreg.api.v1.snapshot.transaction.atomic", return_value=nullcontext()),
+            mock.patch("mreg.api.v1.snapshot.iter_import_items", return_value=ITEMS),
+            mock.patch("mreg.api.v1.snapshot.iter_deferred_record_items", return_value=DEFERRED_RECORDS),
+            mock.patch("mreg.api.v1.snapshot.iter_permission_items", return_value=PERMISSIONS),
+        ):
+            data = _write_snapshot_data(Path(directory), 10, include_permissions=True)
+
+        self.assertEqual(data.items.count, len(ITEMS))
+        self.assertEqual(data.deferred_records.count, len(DEFERRED_RECORDS))
+        self.assertEqual(data.permissions.count, len(PERMISSIONS))
+        self.assertEqual(
+            [call.args[0] for call in cursor.execute.call_args_list],
+            [
+                "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY",
+                "SELECT transaction_timestamp()",
+            ],
+        )
+
+    def test_rejects_non_postgresql_connections(self):
+        connection, _cursor = self.fake_connection(vendor="sqlite")
+        with (
+            tempfile.TemporaryDirectory() as directory,
+            mock.patch("mreg.api.v1.snapshot.connection", connection),
+            mock.patch("mreg.api.v1.snapshot.transaction.atomic", return_value=nullcontext()),
+            self.assertRaisesMessage(SnapshotUnavailable, "consistent PostgreSQL snapshot"),
+        ):
+            _write_snapshot_data(Path(directory), 10, include_permissions=False)
+
+    def test_translates_database_errors(self):
+        connection, _cursor = self.fake_connection(execute_error=DatabaseError("database unavailable"))
+        with (
+            tempfile.TemporaryDirectory() as directory,
+            mock.patch("mreg.api.v1.snapshot.connection", connection),
+            mock.patch("mreg.api.v1.snapshot.transaction.atomic", return_value=nullcontext()),
+            self.assertRaisesMessage(SnapshotUnavailable, "consistent database snapshot could not be read"),
+        ):
+            _write_snapshot_data(Path(directory), 10, include_permissions=False)
+
+
+class SnapshotTranslationValidationTests(ParametrizedTestCase, SimpleTestCase):
+    def ip_row(self, *, pk=1, host_id=1, ipaddress="192.0.2.10", macaddress=None):
+        return SimpleNamespace(
+            pk=pk,
+            host_id=host_id,
+            ipaddress=ipaddress,
+            macaddress=macaddress,
+        )
+
+    def test_wildcard_ip_assignment_rejects_mac_address(self):
+        row = self.ip_row(macaddress="aa:bb:cc:dd:ee:ff")
+        with (
+            mock.patch("mreg.api.v1.snapshot._ip_rows", return_value=[row]),
+            self.assertRaisesMessage(SnapshotError, "Wildcard IP assignment has a MAC address"),
+        ):
+            list(_attachment_items(mock.Mock(), {row.host_id}, 10))
+
+    def test_attachment_requires_a_matching_network(self):
+        row = self.ip_row()
+        index = mock.Mock()
+        index.match.return_value = None
+        with (
+            mock.patch("mreg.api.v1.snapshot._ip_rows", return_value=[row]),
+            self.assertRaisesMessage(SnapshotError, "IP address is not contained in a network"),
+        ):
+            list(_attachment_items(index, set(), 10))
+
+    def test_duplicate_attachment_is_emitted_once(self):
+        rows = [
+            self.ip_row(pk=1, ipaddress="192.0.2.10"),
+            self.ip_row(pk=2, ipaddress="192.0.2.11"),
+        ]
+        index = mock.Mock()
+        index.match.return_value = (7, "192.0.2.0/24")
+        with mock.patch("mreg.api.v1.snapshot._ip_rows", return_value=rows):
+            attachments = list(_attachment_items(index, set(), 10))
+
+        self.assertEqual(len(attachments), 1)
+
+    def ipaddress_model(self, *, duplicate=None, exists=False):
+        manager = mock.MagicMock()
+        duplicate_query = manager.values.return_value.annotate.return_value.filter.return_value.order_by.return_value
+        duplicate_query.first.return_value = duplicate
+        manager.filter.return_value.exists.return_value = exists
+        return SimpleNamespace(objects=manager)
+
+    def test_duplicate_ip_address_is_rejected(self):
+        ipaddress_model = self.ipaddress_model(duplicate={"ipaddress": "192.0.2.10"})
+        with (
+            mock.patch("mreg.api.v1.snapshot.Ipaddress", ipaddress_model),
+            self.assertRaisesMessage(SnapshotError, "assigned more than once"),
+        ):
+            list(_ip_items(mock.Mock(), set(), 10))
+
+    def test_ip_address_requires_a_matching_network(self):
+        row = self.ip_row()
+        index = mock.Mock()
+        index.match.return_value = None
+        with (
+            mock.patch("mreg.api.v1.snapshot.Ipaddress", self.ipaddress_model()),
+            mock.patch("mreg.api.v1.snapshot._ip_rows", return_value=[row]),
+            self.assertRaisesMessage(SnapshotError, "IP address is not contained in a network"),
+        ):
+            list(_ip_items(index, set(), 10))
+
+    def model_with_manager(self, *, hosts=(), exists=False):
+        manager = mock.MagicMock()
+        manager.filter.return_value.exists.return_value = exists
+        manager.filter.return_value.order_by.return_value.iterator.return_value = hosts
+        return SimpleNamespace(objects=manager)
+
+    def wildcard_host(self, *, comment=""):
+        relation = mock.Mock()
+        relation.exists.return_value = False
+        return SimpleNamespace(
+            pk=1,
+            comment=comment,
+            contacts=relation,
+            hostgroups=relation,
+            hostpolicyroles=relation,
+        )
+
+    def test_wildcard_host_requires_dns_data(self):
+        host_model = self.model_with_manager(hosts=[self.wildcard_host()])
+        empty_model = self.model_with_manager()
+        specifications = ((empty_model, "TEST", mock.Mock(), mock.Mock()),)
+        with (
+            mock.patch("mreg.api.v1.snapshot.Host", host_model),
+            mock.patch("mreg.api.v1.snapshot.Ipaddress", empty_model),
+            mock.patch("mreg.api.v1.snapshot._HOST_RECORD_SPECIFICATIONS", specifications),
+            self.assertRaisesMessage(SnapshotError, "has no translatable DNS data"),
+        ):
+            _validate_wildcard_hosts({1}, 10)
+
+    @parametrize(
+        ("comment", "has_bacnet_id"),
+        [
+            param("documented", False, id="comment"),
+            param("", True, id="bacnet_id"),
+        ],
+    )
+    def test_wildcard_host_rejects_non_dns_relationships(self, comment, has_bacnet_id):
+        host = self.wildcard_host(comment=comment)
+        with (
+            mock.patch("mreg.api.v1.snapshot.Host", self.model_with_manager(hosts=[host])),
+            mock.patch("mreg.api.v1.snapshot.Ipaddress", self.model_with_manager(exists=True)),
+            mock.patch("mreg.api.v1.snapshot.BACnetID", self.model_with_manager(exists=has_bacnet_id)),
+            mock.patch("mreg.api.v1.snapshot.HostCommunityMapping", self.model_with_manager()),
+            self.assertRaisesMessage(SnapshotError, "has non-DNS relationships"),
+        ):
+            _validate_wildcard_hosts({1}, 10)
+
+    def test_host_group_cycles_are_rejected(self):
+        group = mock.Mock(pk=1)
+        group.parent.all.return_value = [group]
+        manager = mock.MagicMock()
+        manager.prefetch_related.return_value.order_by.return_value = [group]
+        with (
+            mock.patch("mreg.api.v1.snapshot.HostGroup", SimpleNamespace(objects=manager)),
+            self.assertRaisesMessage(SnapshotError, "contain a cycle"),
+        ):
+            list(_host_group_items(set()))
+
+
+class SnapshotRequestTests(ParametrizedTestCase, SimpleTestCase):
     def setUp(self):
         self.factory = APIRequestFactory()
 
@@ -263,10 +501,16 @@ class SnapshotRequestTests(SimpleTestCase):
         with self.assertRaises(SnapshotRequestError):
             _parse_request(self.request("/api/v1/snapshot?include_audit=true"))
 
-    def test_rejects_explicitly_disabled_gzip(self):
-        for header in ("br, gzip;q=0", "gzip;q=0, *;q=1"):
-            with self.subTest(header=header), self.assertRaises(SnapshotRequestError):
-                _parse_request(self.request("/api/v1/snapshot", HTTP_ACCEPT_ENCODING=header))
+    @parametrize(
+        "header",
+        [
+            param("br, gzip;q=0", id="explicit_gzip"),
+            param("gzip;q=0, *;q=1", id="gzip_overrides_wildcard"),
+        ],
+    )
+    def test_rejects_explicitly_disabled_gzip(self, header):
+        with self.assertRaises(SnapshotRequestError):
+            _parse_request(self.request("/api/v1/snapshot", HTTP_ACCEPT_ENCODING=header))
 
     def test_rejects_explicitly_disabled_media_type(self):
         with self.assertRaises(SnapshotRequestError):
@@ -281,17 +525,33 @@ class SnapshotRequestTests(SimpleTestCase):
         with self.assertRaises(SnapshotRequestError):
             _parse_request(self.request("/api/v1/snapshot?format=mreg-import-json-v1&include_permissions=true"))
 
-    def test_rejects_duplicate_and_unknown_parameters(self):
-        for path in (
-            "/api/v1/snapshot?format=mreg-snapshot-v1&format=mreg-import-json-v1",
-            "/api/v1/snapshot?surprise=true",
-        ):
-            with self.subTest(path=path), self.assertRaises(SnapshotRequestError):
-                _parse_request(self.request(path))
+    def test_rejects_invalid_permissions_value(self):
+        with self.assertRaisesMessage(SnapshotRequestError, "must be 'true' or 'false'"):
+            _parse_request(self.request("/api/v1/snapshot?include_permissions=yes"))
+
+    @parametrize(
+        "path",
+        [
+            param(
+                "/api/v1/snapshot?format=mreg-snapshot-v1&format=mreg-import-json-v1",
+                id="duplicate",
+            ),
+            param("/api/v1/snapshot?surprise=true", id="unknown"),
+        ],
+    )
+    def test_rejects_duplicate_and_unknown_parameters(self, path):
+        with self.assertRaises(SnapshotRequestError):
+            _parse_request(self.request(path))
+
+    def test_header_matching_handles_ranges_and_invalid_values(self):
+        self.assertTrue(_header_allows("application/*", "application/json"))
+        self.assertFalse(_header_allows("gzip;q=invalid", "gzip"))
+        self.assertFalse(_header_allows("gzip;q=2", "gzip"))
+        self.assertFalse(_header_allows("br", "gzip"))
 
 
 @override_settings(MREG_SNAPSHOT_TMPDIR=None, MREG_SNAPSHOT_CHUNK_SIZE=10)
-class SnapshotViewTests(SimpleTestCase):
+class SnapshotViewTests(ParametrizedTestCase, SimpleTestCase):
     def setUp(self):
         self.factory = APIRequestFactory()
 
@@ -360,6 +620,53 @@ class SnapshotViewTests(SimpleTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["Content-Type"], "application/json")
         response.close()
+
+    @parametrize(
+        ("error", "status_code", "error_code"),
+        [
+            param(
+                SnapshotNotAcceptable("not acceptable"),
+                406,
+                "snapshot_not_acceptable",
+                id="not_acceptable",
+            ),
+            param(
+                SnapshotRequestError("invalid request"),
+                400,
+                "invalid_snapshot_request",
+                id="invalid_request",
+            ),
+            param(
+                SnapshotUnavailable("unavailable"),
+                503,
+                "snapshot_unavailable",
+                id="unavailable",
+            ),
+            param(
+                SnapshotError("invalid source", model="Host", object_id=7),
+                409,
+                "snapshot_failed",
+                id="snapshot_error",
+            ),
+            param(
+                OSError("disk unavailable"),
+                503,
+                "snapshot_unavailable",
+                id="os_error",
+            ),
+        ],
+    )
+    def test_snapshot_errors_are_mapped_to_responses(self, error, status_code, error_code):
+        with mock.patch("mreg.api.v1.snapshot.create_snapshot_artifact", side_effect=error):
+            response = SnapshotView.as_view()(self.request(allowed=True))
+        self.assertEqual(response.status_code, status_code)
+        self.assertEqual(response.data["error"], error_code)
+        if isinstance(error, SnapshotError) and error.model is not None:
+            self.assertEqual(response.data["source"], {"model": "Host", "id": 7})
+
+    def test_unsupported_media_type_uses_standard_drf_error_handling(self):
+        response = SnapshotView.as_view()(self.request(allowed=True, HTTP_ACCEPT="text/plain"))
+        self.assertEqual(response.status_code, 406)
 
 
 class SnapshotItemTranslationTests(TestCase):
@@ -552,3 +859,13 @@ class SnapshotItemTranslationTests(TestCase):
                 }
             ],
         )
+
+    def test_network_index_returns_none_when_no_network_matches(self):
+        self.assertIsNone(NetworkIndex().match("203.0.113.1"))
+
+    def test_mx_record_requires_a_forward_zone(self):
+        host = Host.objects.create(name="orphan.example.org")
+        Mx.objects.create(host=host, priority=10, mx="mail.example.org")
+
+        with self.assertRaisesMessage(SnapshotError, "MX owner has no forward zone"):
+            list(_host_dns_record_items(set(), 10, deferred=False))

--- a/mreg/api/v1/tests/test_snapshot.py
+++ b/mreg/api/v1/tests/test_snapshot.py
@@ -155,7 +155,7 @@ class SnapshotArtifactTests(SimpleTestCase):
             artifact.cleanup()
 
     @mock.patch("mreg.api.v1.snapshot._write_snapshot_data", side_effect=fake_write_snapshot_data)
-    def test_compatibility_json_contract(self, _write_snapshot_data):
+    def test_json_import_contract(self, _write_snapshot_data):
         artifact = create_snapshot_artifact(JSON_FORMAT, "snapshotter", "mreg.example.org")
         try:
             with gzip.open(artifact.path, "rt", encoding="utf-8") as source:
@@ -245,7 +245,7 @@ class SnapshotRequestTests(SimpleTestCase):
         self.assertEqual(options.snapshot_format, ARCHIVE_FORMAT)
         self.assertFalse(options.include_permissions)
 
-    def test_accepts_compatibility_json(self):
+    def test_accepts_json_import(self):
         request = self.request(
             "/api/v1/snapshot?format=mreg-import-json-v1",
             HTTP_ACCEPT="application/json",
@@ -277,7 +277,7 @@ class SnapshotRequestTests(SimpleTestCase):
                 )
             )
 
-    def test_rejects_permissions_for_compatibility_json(self):
+    def test_rejects_permissions_for_json_import(self):
         with self.assertRaises(SnapshotRequestError):
             _parse_request(self.request("/api/v1/snapshot?format=mreg-import-json-v1&include_permissions=true"))
 
@@ -334,7 +334,7 @@ class SnapshotViewTests(SimpleTestCase):
         self.assertFalse(artifact_path.exists())
 
     @mock.patch("mreg.api.v1.snapshot._write_snapshot_data", side_effect=fake_write_snapshot_data)
-    def test_compatibility_media_type_is_negotiated(self, _write_snapshot_data):
+    def test_json_import_media_type_is_negotiated(self, _write_snapshot_data):
         response = SnapshotView.as_view()(
             self.request(
                 allowed=True,

--- a/mreg/api/v1/tests/test_snapshot.py
+++ b/mreg/api/v1/tests/test_snapshot.py
@@ -1,0 +1,429 @@
+import gzip
+import hashlib
+import io
+import json
+import tarfile
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest import mock
+
+from django.contrib.auth.models import Group
+from django.test import SimpleTestCase, TestCase, override_settings
+from rest_framework.request import Request
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from mreg.api.v1.snapshot import (
+    ARCHIVE_FORMAT,
+    JSON_FORMAT,
+    SnapshotRequestError,
+    SnapshotView,
+    _parse_loc,
+    _parse_request,
+    create_snapshot_artifact,
+    iter_import_items,
+    iter_permission_items,
+)
+from hostpolicy.models import HostPolicyAtom, HostPolicyRole
+from mreg.models.base import Label, NameServer
+from mreg.models.host import BACnetID, Host, HostContact, HostGroup, Ipaddress, PtrOverride
+from mreg.models.network import NetGroupRegexPermission, Network, NetworkExcludedRange
+from mreg.models.network_policy import (
+    Community,
+    HostCommunityMapping,
+    NetworkPolicy,
+    NetworkPolicyAttribute,
+    NetworkPolicyAttributeValue,
+)
+from mreg.models.resource_records import Cname, Hinfo, Loc, Mx, Naptr, Srv, Sshfp, Txt
+from mreg.models.zone import ForwardZone, ForwardZoneDelegation, ReverseZone, ReverseZoneDelegation
+
+
+ITEMS = [
+    {
+        "ref": "nameserver:1",
+        "kind": "nameserver",
+        "operation": "create",
+        "attributes": {"name": "ns1.example.org"},
+    },
+    {
+        "ref": "forward_zone:1",
+        "kind": "forward_zone",
+        "operation": "create",
+        "attributes": {
+            "name": "example.org",
+            "primary_ns": "ns1.example.org",
+            "nameservers": ["nameserver:1"],
+            "email": "hostmaster@example.org",
+        },
+    },
+]
+
+PERMISSIONS = [
+    {
+        "ref": "netgroup_regex_permission:7",
+        "kind": "netgroup_regex_permission",
+        "operation": "create",
+        "attributes": {
+            "group": "dns-admins",
+            "range": "192.0.2.0/24",
+            "regex": r".*\.example\.org",
+            "labels": ["production"],
+        },
+    }
+]
+
+
+def write_values(path, values):
+    digest = hashlib.sha256()
+    with path.open("wb") as output:
+        for value in values:
+            line = json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode() + b"\n"
+            output.write(line)
+            digest.update(line)
+    return len(values), digest.hexdigest()
+
+
+def fake_write_snapshot_data(items_path, permissions_path, chunk_size):
+    item_count, item_sha256 = write_values(items_path, ITEMS)
+    if permissions_path is None:
+        permission_count, permission_sha256 = None, None
+    else:
+        permission_count, permission_sha256 = write_values(permissions_path, PERMISSIONS)
+    return (
+        item_count,
+        item_sha256,
+        permission_count,
+        permission_sha256,
+        datetime(2026, 7, 12, 10, 14, 58, tzinfo=timezone.utc),
+    )
+
+
+@override_settings(MREG_SNAPSHOT_TMPDIR=None, MREG_SNAPSHOT_CHUNK_SIZE=10)
+class SnapshotArtifactTests(SimpleTestCase):
+    @mock.patch("mreg.api.v1.snapshot._write_snapshot_data", side_effect=fake_write_snapshot_data)
+    def test_archive_contract(self, _write_snapshot_data):
+        artifact = create_snapshot_artifact(ARCHIVE_FORMAT, "snapshotter", "mreg.example.org")
+        try:
+            compressed = artifact.path.read_bytes()
+            self.assertEqual(hashlib.sha256(compressed).hexdigest(), artifact.digest_hex)
+            with tarfile.open(fileobj=io.BytesIO(compressed), mode="r:gz") as archive:
+                self.assertEqual(archive.getnames(), ["manifest.json", "items.ndjson"])
+                manifest = json.load(archive.extractfile("manifest.json"))
+                item_bytes = archive.extractfile("items.ndjson").read()
+            self.assertEqual(manifest["format"], "no.uio.mreg.snapshot")
+            self.assertEqual(manifest["format_version"], 1)
+            self.assertTrue(manifest["snapshot"]["consistent"])
+            self.assertEqual(manifest["items"]["count"], 2)
+            self.assertEqual(manifest["items"]["sha256"], hashlib.sha256(item_bytes).hexdigest())
+            self.assertEqual([json.loads(line) for line in item_bytes.splitlines()], ITEMS)
+        finally:
+            artifact.temporary_directory.cleanup()
+
+    @mock.patch("mreg.api.v1.snapshot._write_snapshot_data", side_effect=fake_write_snapshot_data)
+    def test_compatibility_json_contract(self, _write_snapshot_data):
+        artifact = create_snapshot_artifact(JSON_FORMAT, "snapshotter", "mreg.example.org")
+        try:
+            with gzip.open(artifact.path, "rt", encoding="utf-8") as source:
+                document = json.load(source)
+            self.assertEqual(document, {"requested_by": "snapshotter", "items": ITEMS})
+        finally:
+            artifact.temporary_directory.cleanup()
+
+    @mock.patch("mreg.api.v1.snapshot._write_snapshot_data", side_effect=fake_write_snapshot_data)
+    def test_archive_can_include_permissions(self, _write_snapshot_data):
+        artifact = create_snapshot_artifact(
+            ARCHIVE_FORMAT,
+            "snapshotter",
+            "mreg.example.org",
+            include_permissions=True,
+        )
+        try:
+            with tarfile.open(artifact.path, mode="r:gz") as archive:
+                self.assertEqual(
+                    archive.getnames(),
+                    ["manifest.json", "items.ndjson", "permissions.ndjson"],
+                )
+                manifest = json.load(archive.extractfile("manifest.json"))
+                permission_bytes = archive.extractfile("permissions.ndjson").read()
+            self.assertTrue(manifest["semantics"]["permissions_included"])
+            self.assertEqual(manifest["permissions"]["count"], 1)
+            self.assertEqual(
+                manifest["permissions"]["sha256"],
+                hashlib.sha256(permission_bytes).hexdigest(),
+            )
+            self.assertEqual(
+                [json.loads(line) for line in permission_bytes.splitlines()],
+                PERMISSIONS,
+            )
+        finally:
+            artifact.temporary_directory.cleanup()
+
+    def test_loc_conversion(self):
+        value = _parse_loc("42 21 54 N 71 06 18 W -24m 30m", pk=1)
+        self.assertAlmostEqual(value["latitude"], 42.365)
+        self.assertAlmostEqual(value["longitude"], -71.105)
+        self.assertEqual(value["altitude_m"], -24)
+        self.assertEqual(value["size_m"], 30)
+
+
+class SnapshotRequestTests(SimpleTestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+
+    def request(self, path, **headers):
+        return Request(self.factory.get(path, **headers))
+
+    def test_defaults_to_archive(self):
+        options = _parse_request(self.request("/api/v1/snapshot"))
+        self.assertEqual(options.snapshot_format, ARCHIVE_FORMAT)
+        self.assertFalse(options.include_permissions)
+
+    def test_accepts_compatibility_json(self):
+        request = self.request(
+            "/api/v1/snapshot?format=mreg-import-json-v1",
+            HTTP_ACCEPT="application/json",
+            HTTP_ACCEPT_ENCODING="gzip",
+        )
+        options = _parse_request(request)
+        self.assertEqual(options.snapshot_format, JSON_FORMAT)
+        self.assertFalse(options.include_permissions)
+
+    def test_accepts_permissions_for_archive(self):
+        options = _parse_request(
+            self.request("/api/v1/snapshot?include_permissions=true")
+        )
+        self.assertTrue(options.include_permissions)
+
+    def test_rejects_non_default_options(self):
+        with self.assertRaises(SnapshotRequestError):
+            _parse_request(self.request("/api/v1/snapshot?include_audit=true"))
+
+    def test_rejects_explicitly_disabled_gzip(self):
+        with self.assertRaises(SnapshotRequestError):
+            _parse_request(
+                self.request("/api/v1/snapshot", HTTP_ACCEPT_ENCODING="br, gzip;q=0")
+            )
+
+    def test_rejects_permissions_for_compatibility_json(self):
+        with self.assertRaises(SnapshotRequestError):
+            _parse_request(
+                self.request(
+                    "/api/v1/snapshot?format=mreg-import-json-v1&include_permissions=true"
+                )
+            )
+
+    def test_rejects_duplicate_and_unknown_parameters(self):
+        for path in (
+            "/api/v1/snapshot?format=mreg-snapshot-v1&format=mreg-import-json-v1",
+            "/api/v1/snapshot?surprise=true",
+        ):
+            with self.subTest(path=path), self.assertRaises(SnapshotRequestError):
+                _parse_request(self.request(path))
+
+
+@override_settings(MREG_SNAPSHOT_TMPDIR=None, MREG_SNAPSHOT_CHUNK_SIZE=10)
+class SnapshotViewTests(SimpleTestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+
+    def request(self, *, allowed):
+        request = self.factory.get("/api/v1/snapshot")
+        user = SimpleNamespace(
+            is_authenticated=True,
+            is_mreg_snapshotter=allowed,
+            username="snapshotter",
+        )
+        force_authenticate(request, user=user)
+        return request
+
+    def test_dedicated_permission_is_required(self):
+        response = SnapshotView.as_view()(self.request(allowed=False))
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.data["error"], "snapshot_forbidden")
+
+    @mock.patch("mreg.api.v1.snapshot._write_snapshot_data", side_effect=fake_write_snapshot_data)
+    def test_response_headers_and_cleanup(self, _write_snapshot_data):
+        response = SnapshotView.as_view()(self.request(allowed=True))
+        artifact_path = response.artifact.path
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Encoding"], "gzip")
+        self.assertTrue(response["Digest"].startswith("sha-256=:"))
+        self.assertTrue(response["ETag"].startswith('"snapshot-'))
+        self.assertEqual(response["Cache-Control"], "private, no-store")
+        self.assertTrue(artifact_path.exists())
+        b"".join(response.streaming_content)
+        response.close()
+        self.assertFalse(artifact_path.exists())
+
+
+class SnapshotItemTranslationTests(TestCase):
+    """Exercise the complete successful legacy-to-snapshot translation graph."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.label = Label.objects.create(name="production", description="Production")
+        cls.nameserver = NameServer.objects.create(name="ns1.example.org", ttl=3600)
+        permission = NetGroupRegexPermission.objects.create(
+            group="dns-admins",
+            range="192.0.2.0/24",
+            regex=r".*\.example\.org",
+        )
+        permission.labels.add(cls.label)
+
+        cls.attribute = NetworkPolicyAttribute.objects.create(name="isolated", description="Isolation")
+        cls.policy = NetworkPolicy.objects.create(
+            name="campus", description="Campus policy", community_template_pattern="community"
+        )
+        NetworkPolicyAttributeValue.objects.create(policy=cls.policy, attribute=cls.attribute, value=True)
+        cls.network = Network.objects.create(
+            network="192.0.2.0/24",
+            description="Example network",
+            vlan=123,
+            dns_delegated=True,
+            category="server",
+            location="Oslo",
+            reserved=2,
+            max_communities=5,
+            policy=cls.policy,
+        )
+        NetworkExcludedRange.objects.create(network=cls.network, start_ip="192.0.2.200", end_ip="192.0.2.210")
+        cls.community = Community.objects.create(name="web", description="Web", network=cls.network)
+
+        cls.forward_zone = ForwardZone.objects.create(
+            name="example.org",
+            primary_ns=cls.nameserver.name,
+            email="hostmaster@example.org",
+        )
+        cls.forward_zone.nameservers.add(cls.nameserver)
+        cls.reverse_zone = ReverseZone.objects.create(
+            name="2.0.192.in-addr.arpa",
+            primary_ns=cls.nameserver.name,
+            email="hostmaster@example.org",
+        )
+        cls.reverse_zone.nameservers.add(cls.nameserver)
+        forward_delegation = ForwardZoneDelegation.objects.create(
+            zone=cls.forward_zone, name="delegated.example.org", comment="Delegated"
+        )
+        forward_delegation.nameservers.add(cls.nameserver)
+        reverse_delegation = ReverseZoneDelegation.objects.create(
+            zone=cls.reverse_zone, name="128-25.2.0.192.in-addr.arpa", comment="Delegated"
+        )
+        reverse_delegation.nameservers.add(cls.nameserver)
+
+        cls.host = Host.objects.create(name="app.example.org", zone=cls.forward_zone, ttl=600, comment="Application")
+        cls.ip = Ipaddress.objects.create(host=cls.host, ipaddress="192.0.2.20", macaddress="aa:bb:cc:dd:ee:ff")
+        Hinfo.objects.create(host=cls.host, cpu="x86_64", os="Linux")
+        Loc.objects.create(host=cls.host, loc="59 54 0 N 10 42 0 E 50m 1m 2m 3m")
+        Mx.objects.create(host=cls.host, priority=10, mx="mail.example.org")
+        Txt.objects.create(host=cls.host, txt="v=spf1 -all")
+        Naptr.objects.create(
+            host=cls.host,
+            order=100,
+            preference=10,
+            flag="s",
+            service="sip",
+            regex="",
+            replacement="sip.example.org",
+        )
+        Sshfp.objects.create(
+            host=cls.host,
+            ttl=300,
+            algorithm=4,
+            hash_type=2,
+            fingerprint="a" * 64,
+        )
+        Cname.objects.create(host=cls.host, zone=cls.forward_zone, name="alias.example.org", ttl=300)
+        Srv.objects.create(
+            host=cls.host,
+            zone=cls.forward_zone,
+            name="_https._tcp.example.org",
+            priority=10,
+            weight=5,
+            port=443,
+            ttl=300,
+        )
+        PtrOverride.objects.create(host=cls.host, ipaddress=cls.ip.ipaddress)
+        BACnetID.objects.create(id=42, host=cls.host)
+        contact = HostContact.objects.create(email="operator@example.org")
+        contact.hosts.add(cls.host)
+
+        owner = Group.objects.create(name="network-operators")
+        parent = HostGroup.objects.create(name="all-servers", description="All servers")
+        child = HostGroup.objects.create(name="web-servers", description="Web servers")
+        child.parent.add(parent)
+        child.hosts.add(cls.host)
+        child.owners.add(owner)
+        HostCommunityMapping.objects.create(host=cls.host, ipaddress=cls.ip, community=cls.community)
+
+        atom = HostPolicyAtom.objects.create(name="patched", description="Patched")
+        role = HostPolicyRole.objects.create(name="web", description="Web role")
+        role.atoms.add(atom)
+        role.hosts.add(cls.host)
+        role.labels.add(cls.label)
+
+        wildcard = Host.objects.create(name="*.wild.example.org", zone=cls.forward_zone, ttl=120)
+        Ipaddress.objects.create(host=wildcard, ipaddress="192.0.2.99")
+        Txt.objects.create(host=wildcard, txt="wildcard")
+
+    def test_dependency_ordered_translation_covers_supported_legacy_models(self):
+        items = list(iter_import_items(10))
+        json.dumps(items)
+        kinds = {item["kind"] for item in items}
+        self.assertTrue(
+            {
+                "label",
+                "nameserver",
+                "network_policy_attribute",
+                "network_policy",
+                "network_policy_attribute_value",
+                "network",
+                "excluded_range",
+                "community",
+                "forward_zone",
+                "reverse_zone",
+                "forward_zone_delegation",
+                "reverse_zone_delegation",
+                "host",
+                "host_attachment",
+                "ip_address",
+                "record",
+                "ptr_override",
+                "bacnet_id",
+                "host_contact",
+                "host_group",
+                "attachment_community_assignment",
+                "host_policy_atom",
+                "host_policy_role",
+                "host_policy_role_atom",
+                "host_policy_role_host",
+                "host_policy_role_label",
+            }
+            <= kinds
+        )
+        positions = {item["ref"]: index for index, item in enumerate(items)}
+        attachment = next(item for item in items if item["kind"] == "host_attachment")
+        address = next(item for item in items if item["kind"] == "ip_address")
+        self.assertLess(positions[attachment["ref"]], positions[address["ref"]])
+        self.assertEqual(address["attributes"]["attachment_id_ref"], attachment["ref"])
+        wildcard_records = [
+            item for item in items if item["kind"] == "record" and item["attributes"]["owner_name"] == "*.wild.example.org"
+        ]
+        self.assertEqual({item["attributes"]["type_name"] for item in wildcard_records}, {"A", "TXT"})
+
+        permissions = list(iter_permission_items(10))
+        self.assertEqual(
+            permissions,
+            [
+                {
+                    "ref": f"netgroup_regex_permission:{NetGroupRegexPermission.objects.get().pk}",
+                    "kind": "netgroup_regex_permission",
+                    "operation": "create",
+                    "attributes": {
+                        "group": "dns-admins",
+                        "range": "192.0.2.0/24",
+                        "regex": r".*\.example\.org",
+                        "labels": ["production"],
+                    },
+                }
+            ],
+        )

--- a/mreg/api/v1/tests/test_snapshot.py
+++ b/mreg/api/v1/tests/test_snapshot.py
@@ -15,6 +15,8 @@ from rest_framework.test import APIRequestFactory, force_authenticate
 from mreg.api.v1.snapshot import (
     ARCHIVE_FORMAT,
     JSON_FORMAT,
+    SnapshotData,
+    SnapshotDataFile,
     SnapshotRequestError,
     SnapshotView,
     _parse_loc,
@@ -99,27 +101,21 @@ def write_values(path, values):
             line = json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode() + b"\n"
             output.write(line)
             digest.update(line)
-    return len(values), digest.hexdigest()
+    return SnapshotDataFile(path=path, count=len(values), sha256=digest.hexdigest())
 
 
-def fake_write_snapshot_data(items_path, deferred_records_path, permissions_path, chunk_size):
-    item_count, item_sha256 = write_values(items_path, ITEMS)
-    deferred_count, deferred_sha256 = write_values(
-        deferred_records_path,
+def fake_write_snapshot_data(directory, chunk_size, *, include_permissions):
+    items = write_values(directory / "items.ndjson", ITEMS)
+    deferred_records = write_values(
+        directory / "deferred-records.ndjson",
         DEFERRED_RECORDS,
     )
-    if permissions_path is None:
-        permission_count, permission_sha256 = None, None
-    else:
-        permission_count, permission_sha256 = write_values(permissions_path, PERMISSIONS)
-    return (
-        item_count,
-        item_sha256,
-        deferred_count,
-        deferred_sha256,
-        permission_count,
-        permission_sha256,
-        datetime(2026, 7, 12, 10, 14, 58, tzinfo=timezone.utc),
+    permissions = write_values(directory / "permissions.ndjson", PERMISSIONS) if include_permissions else None
+    return SnapshotData(
+        items=items,
+        deferred_records=deferred_records,
+        permissions=permissions,
+        database_timestamp=datetime(2026, 7, 12, 10, 14, 58, tzinfo=timezone.utc),
     )
 
 
@@ -156,7 +152,7 @@ class SnapshotArtifactTests(SimpleTestCase):
                 DEFERRED_RECORDS,
             )
         finally:
-            artifact.temporary_directory.cleanup()
+            artifact.cleanup()
 
     @mock.patch("mreg.api.v1.snapshot._write_snapshot_data", side_effect=fake_write_snapshot_data)
     def test_compatibility_json_contract(self, _write_snapshot_data):
@@ -173,7 +169,7 @@ class SnapshotArtifactTests(SimpleTestCase):
                 },
             )
         finally:
-            artifact.temporary_directory.cleanup()
+            artifact.cleanup()
 
     @mock.patch("mreg.api.v1.snapshot._write_snapshot_data", side_effect=fake_write_snapshot_data)
     def test_archive_can_include_permissions(self, _write_snapshot_data):
@@ -207,7 +203,22 @@ class SnapshotArtifactTests(SimpleTestCase):
                 PERMISSIONS,
             )
         finally:
-            artifact.temporary_directory.cleanup()
+            artifact.cleanup()
+
+    def test_rejects_invalid_direct_options(self):
+        invalid_options = (
+            ("unsupported", False),
+            (JSON_FORMAT, True),
+        )
+        for snapshot_format, include_permissions in invalid_options:
+            with self.subTest(snapshot_format=snapshot_format, include_permissions=include_permissions):
+                with self.assertRaises(SnapshotRequestError):
+                    create_snapshot_artifact(
+                        snapshot_format,
+                        "snapshotter",
+                        "mreg.example.org",
+                        include_permissions=include_permissions,
+                    )
 
     def test_loc_conversion(self):
         value = _parse_loc("42 21 54 N 71 06 18 W -24m 30m", pk=1)
@@ -296,7 +307,9 @@ class SnapshotViewTests(SimpleTestCase):
 
     def test_dedicated_permission_is_required(self):
         response = SnapshotView.as_view()(self.request(allowed=False))
+        response.render()
         self.assertEqual(response.status_code, 403)
+        self.assertEqual(response["Content-Type"], "application/json")
         self.assertEqual(response.data["error"], "snapshot_forbidden")
 
     @mock.patch("mreg.api.v1.snapshot._write_snapshot_data", side_effect=fake_write_snapshot_data)

--- a/mreg/api/v1/tests/test_snapshot.py
+++ b/mreg/api/v1/tests/test_snapshot.py
@@ -295,11 +295,12 @@ class SnapshotViewTests(SimpleTestCase):
     def setUp(self):
         self.factory = APIRequestFactory()
 
-    def request(self, *, allowed, path="/api/v1/snapshot", **headers):
+    def request(self, *, allowed, admin=False, path="/api/v1/snapshot", **headers):
         request = self.factory.get(path, **headers)
         user = SimpleNamespace(
             is_authenticated=True,
             is_mreg_snapshotter=allowed,
+            is_mreg_superuser_or_admin=admin,
             username="snapshotter",
         )
         force_authenticate(request, user=user)
@@ -311,6 +312,19 @@ class SnapshotViewTests(SimpleTestCase):
         self.assertEqual(response.status_code, 403)
         self.assertEqual(response["Content-Type"], "application/json")
         self.assertEqual(response.data["error"], "snapshot_forbidden")
+
+    @mock.patch("mreg.api.v1.snapshot._write_snapshot_data", side_effect=fake_write_snapshot_data)
+    def test_mreg_admin_can_create_snapshot(self, _write_snapshot_data):
+        response = SnapshotView.as_view()(
+            self.request(
+                allowed=False,
+                admin=True,
+                HTTP_ACCEPT="application/vnd.uio.mreg-snapshot+tar",
+                HTTP_ACCEPT_ENCODING="gzip",
+            )
+        )
+        self.assertEqual(response.status_code, 200)
+        response.close()
 
     @mock.patch("mreg.api.v1.snapshot._write_snapshot_data", side_effect=fake_write_snapshot_data)
     def test_response_headers_and_cleanup(self, _write_snapshot_data):

--- a/mreg/api/v1/urls.py
+++ b/mreg/api/v1/urls.py
@@ -3,8 +3,10 @@ from django.urls import path, re_path
 from . import views, views_hostgroups, views_zones, views_labels, views_bacnet, views_network_policy
 
 from .endpoints import URL
+from .snapshot import SnapshotView
 
 urlpatterns = [
+     path('snapshot', SnapshotView.as_view(), name='snapshot'),
      path('bacnet/ids/', views_bacnet.BACnetIDList.as_view()),
      path('bacnet/ids/<id>', views_bacnet.BACnetIDDetail.as_view()),
      path('cnames/', views.CnameList.as_view()),

--- a/mreg/api/v1/urls.py
+++ b/mreg/api/v1/urls.py
@@ -6,7 +6,7 @@ from .endpoints import URL
 from .snapshot import SnapshotView
 
 urlpatterns = [
-     path('snapshot', SnapshotView.as_view(), name='snapshot'),
+    path("snapshot", SnapshotView.as_view(), name="snapshot"),
      path('bacnet/ids/', views_bacnet.BACnetIDList.as_view()),
      path('bacnet/ids/<id>', views_bacnet.BACnetIDDetail.as_view()),
      path('cnames/', views.CnameList.as_view()),

--- a/mreg/models/auth.py
+++ b/mreg/models/auth.py
@@ -35,6 +35,7 @@ class MregAdminGroup(enum.Enum):
     DNS_WILDCARD = "DNS_WILDCARD_GROUP"
     DNS_UNDERSCORE = "DNS_UNDERSCORE_GROUP"
     HOSTPOLICY_ADMIN = "HOSTPOLICYADMIN_GROUP"
+    SNAPSHOT = "SNAPSHOT_GROUP"
 
     def settings_groups_or_raise(self) -> list[str]:
         """Get the group names from the settings, or raise an exception if unset.
@@ -129,6 +130,11 @@ class User(AbstractUser):
         A user with this permission can create, delete, and modify hostpolicy roles / atoms.
         """
         return self.is_member_of_any(MregAdminGroup.HOSTPOLICY_ADMIN.settings_groups_or_raise())
+
+    @cached_property
+    def is_mreg_snapshotter(self) -> bool:
+        """Check whether the user may create and download portable snapshots."""
+        return self.is_member_of_any(MregAdminGroup.SNAPSHOT.settings_groups_or_raise())
 
     @cached_property
     def is_mreg_superuser_or_admin(self) -> bool:

--- a/mregsite/settings.py
+++ b/mregsite/settings.py
@@ -143,6 +143,12 @@ MREG_DB_POOL_MAX_LIFETIME = envvar("MREG_DB_POOL_MAX_LIFETIME", 3600)
 MREG_DB_PSYCOPG_CONNECT_TIMEOUT = envvar("MREG_DB_PSYCOPG_CONNECT_TIMEOUT", 5)
 MREG_DB_PSYCOPG_OPTIONS = envvar("MREG_DB_PSYCOPG_OPTIONS", "-c statement_timeout=30000")
 
+# Portable snapshots contain the full domain dataset and therefore use
+# a separate, narrowly assigned authorization group.
+SNAPSHOT_GROUP = envvar("MREG_SNAPSHOT_GROUP", "mreg-snapshot")
+MREG_SNAPSHOT_TMPDIR = os.environ.get("MREG_SNAPSHOT_TMPDIR") or None
+MREG_SNAPSHOT_CHUNK_SIZE = envvar("MREG_SNAPSHOT_CHUNK_SIZE", 2000)
+
 # If the log directory doesn't exist, create it.
 log_dir = os.path.dirname(LOG_FILE_NAME)
 if not os.path.exists(log_dir): # pragma: no cover
@@ -455,6 +461,7 @@ if TESTING or "CI" in os.environ:
     HOSTPOLICYADMIN_GROUP = "default-hostpolicyadmin-group"
     DNS_WILDCARD_GROUP = "default-dns-wildcard-group"
     DNS_UNDERSCORE_GROUP = "default-dns-underscore-group"
+    SNAPSHOT_GROUP = "default-snapshot-group"
 
 
 def get_pool_settings() -> dict[str, int] | Literal[False]:


### PR DESCRIPTION
## Summary

- add a synchronous, versioned portable snapshot endpoint with archive and single-file JSON representations
- export domain data from a consistent PostgreSQL transaction, with optional legacy permissions and deterministic checksums
- preserve wildcard HINFO, LOC, and SSHFP records that cannot be imported automatically as explicit deferred records
- split oversized TXT values into valid DNS character strings and tighten HTTP content negotiation and digest headers
- centralize snapshot authorization and refactor DNS translation, manifest construction, archive writing, hashing, and temporary-file cleanup into focused components

## Impact

Operators can create implementation-independent backups for transfer and recovery workflows without holding a database transaction open during download. Existing users, tokens, audit history, and authorization memberships remain excluded. Snapshot access is available to members of the dedicated configured group, MREG administrators, and MREG superusers.

The JSON representation delivers a pure, single-file, dependency-ordered JSON import document, while records that cannot be imported automatically are surfaced separately for manual handling.

## Validation

- complete Django suite with PostgreSQL connection pooling enabled: 999 tests, 997 passed, 2 skipped
- local fresh line coverage: 97.885%
- Coveralls coverage: 97.859%, up 0.09 percentage points from `master` at 97.767%
- snapshot module line coverage: 98.390%
- `uv run ruff check mreg/api/v1/tests/test_snapshot.py`
- `uv run ruff format --check mreg/api/v1/tests/test_snapshot.py`
- `git diff --check`
