### PR TITLE
CI: use the local MREG image for mreg-cli tests

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -65,6 +65,10 @@ jobs:
     name: Test with mreg-cli
     needs: build
     runs-on: ubuntu-latest
+    env:
+      # This image exists only in the runner's local Docker image store.
+      MREG_IMAGE: mreg:ci
+      MREG_IMAGE_PULL_POLICY: never
     steps:
     - name: Download artifact
       uses: actions/download-artifact@v8
@@ -72,10 +76,8 @@ jobs:
         name: mreg
     - name: Load container image
       run: docker load --input mreg.tgz
-    - name: Tag container image
-      # There's a docker-compose.yml file in the mreg-cli repo that wants the image from ghcr.io,
-      # but we want to use the newly built custom image
-      run: docker tag mreg ghcr.io/unioslo/mreg:latest
+    - name: Tag local image for mreg-cli
+      run: docker tag mreg:latest "$MREG_IMAGE"
     - name: Checkout
       uses: actions/checkout@v6
     - name: Download mreg-cli
@@ -89,8 +91,6 @@ jobs:
         git -c advice.detachedHead=false checkout $C
         cp --no-clobber /tmp/ci/* ci/
     - name: Run the tests
-      env:
-        MREG_IMAGE: ghcr.io/unioslo/mreg:latest
       run: mreg-cli/ci/run_testsuite_and_record_V2.sh
     - name: Comment on the commit that the tests worked
       run: |

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -66,7 +66,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     env:
-      # This image exists only in the runner's local Docker image store.
+      # These vars are sourced by mreg-cli's `run_testsuite_and_record_V2.sh`
+      # Ensures we use local image (with unique CI tag), not image pulled from registry.
       MREG_IMAGE: mreg:ci
       MREG_IMAGE_PULL_POLICY: never
     steps:


### PR DESCRIPTION
## Summary

- give the workflow-built MREG image a clear local CI tag
- configure the mreg-cli compatibility test to prohibit registry pulls
- keep the default pull-request merge checkout so CI tests the would-be merge result

## Why

Docker Compose always pulls images tagged `latest`, so the compatibility job could replace the workflow-built image with a registry image. The local `mreg:ci` tag avoids the special `latest` behavior, while `MREG_IMAGE_PULL_POLICY=never` makes the local-only requirement explicit through unioslo/mreg-cli#467.

## Validation

- `actionlint -shellcheck "" .github/workflows/container-image.yml`
- `git diff --check`